### PR TITLE
Remove double quotes around macros

### DIFF
--- a/src/components/samples.ts
+++ b/src/components/samples.ts
@@ -23,26 +23,26 @@ export const sampleQueries: Array<SelectableValue<string>> = [
   {
     label: 'Show databases',
     value: 'SHOW DATABASES',
-    description: 'List the databases available in your instance',
+    description: 'List databases available in your instance',
   },
   {
     label: 'Show tables',
-    value: 'SHOW TABLES FROM "$__database"',
-    description: 'List the tables within a database',
+    value: 'SHOW TABLES FROM $__database',
+    description: 'List tables in the selected database',
   },
   {
     label: 'Describe table',
-    value: 'DESCRIBE "$__database"."$__table"',
-    description: 'describe a table in a database',
+    value: 'DESCRIBE $__database.$__table',
+    description: 'Describe the selected table',
   },
   {
     label: 'Show measurements',
-    value: 'SHOW MEASURES FROM "$__database"."$__table"',
-    description: 'Show measurements in the selected table',
+    value: 'SHOW MEASURES FROM $__database.$__table',
+    description: 'List measurements in the selected table',
   },
   {
     label: 'First 10 rows',
-    value: 'SELECT * FROM "$__database"."$__table" LIMIT 10',
-    description: 'Select the first 10 rows of the table',
+    value: 'SELECT * FROM $__database.$__table LIMIT 10',
+    description: 'Select the first 10 rows of the selected table',
   },
 ];


### PR DESCRIPTION
## Why is this change required?
- Wrapping a macro in double quotes makes it an identifier

## Does this commit cause any expected behaviors to change? If so, what?
- None