### PR TITLE
Pass `scopedVars` without `$__interval_ms` when interpolating

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -57,7 +57,7 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     }
 
     // create a copy of scopedVars without $__interval_ms for using with rawQuery
-    const {__interval_ms, __interval, ...queryScopedVars} = scopedVars;
+    const { __interval_ms, __interval, ...queryScopedVars } = scopedVars;
 
     const templateSrv = getTemplateSrv();
     return {

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -65,7 +65,7 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
       database: templateSrv.replace(query.database || '', scopedVars),
       table: templateSrv.replace(query.table || '', scopedVars),
       measure: templateSrv.replace(query.measure || '', scopedVars),
-      rawQuery: templateSrv.replace(query.rawQuery, scopedVarsWithoutTimestamp), // DO NOT include scopedVars! it uses $__interval_ms!!!!!
+      rawQuery: templateSrv.replace(query.rawQuery, queryScopedVars), // DO NOT include scopedVars! it uses $__interval_ms!!!!!
     };
   }
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -56,13 +56,17 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
       return query;
     }
 
+    // create a copy of scopedVars without $__interval_ms for using with rawQuery
+    var scopedVarsWithoutTimestamp = Object.assign({}, scopedVars);
+    delete scopedVars.__interval_ms;
+
     const templateSrv = getTemplateSrv();
     return {
       ...query,
       database: templateSrv.replace(query.database || '', scopedVars),
       table: templateSrv.replace(query.table || '', scopedVars),
       measure: templateSrv.replace(query.measure || '', scopedVars),
-      rawQuery: templateSrv.replace(query.rawQuery), // DO NOT include scopedVars! it uses $__interval_ms!!!!!
+      rawQuery: templateSrv.replace(query.rawQuery, scopedVarsWithoutTimestamp), // DO NOT include scopedVars! it uses $__interval_ms!!!!!
     };
   }
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -57,8 +57,7 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     }
 
     // create a copy of scopedVars without $__interval_ms for using with rawQuery
-    var scopedVarsWithoutTimestamp = Object.assign({}, scopedVars);
-    delete scopedVars.__interval_ms;
+    const {__interval_ms, __interval, ...queryScopedVars} = scopedVars;
 
     const templateSrv = getTemplateSrv();
     return {


### PR DESCRIPTION
## Why is this change required?
- We need to pass `scopedVars` if we want repeating panel to work
- This will fix #22 

## How does this change solve the issue?
- Due to a comment about `DO NOT include scopedVars! it uses
$__interval_ms!!!!!`, we remove the value from `scopedVars` before
passing it

## Does this commit cause any expected behaviors to change? If so, what?
- None