### PR TITLE
Add an instruction to build plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ datasources:
 ## How to build this datasource
 You will need to install [Node.js](https://nodejs.org/en/), [Yarn](https://yarnpkg.com/), [Go](https://golang.org/), and [Mage](https://magefile.org/) first.
 1. `yarn install --frozen-lockfile`
-1. `yarn dev`
+1. `yarn dev` will build your frontend changes
+1. `mage build:backend` -- will build the backend changes
 1. (Optional) `mage -v buildAll` This is optional if you need backend plugins for other platforms.
 1. [Sign the plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/), or configure Grafana to [load the unsigned plugin](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins).
 1. The compiled plugin should be in `dist/` directory.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,15 @@ datasources:
       accessKey: '<your access key>'
       secretKey: '<your secret key>'
 ```
+
+## How to build this datasource
+You will need to install [Node.js](https://nodejs.org/en/), [Yarn](https://yarnpkg.com/), [Go](https://golang.org/), and [Mage](https://magefile.org/) first.
+1. `yarn install --frozen-lockfile`
+1. `rm -rf node_modules/@grafana/data/node_modules`
+1. `npm run build`
+1. (Optional) `mage -v buildAll` This is optional if you need backend plugins for other platforms.
+1. [Sign the plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/), or configure Grafana to [load the unsigned plugin](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins).
+1. The compiled plugin should be in `dist/` directory.
+1. You can install by following the [install Grafana plugins docs page](https://grafana.com/docs/grafana/latest/plugins/installation/).
+
+For more information, please consult the [build a plugin docs page](https://grafana.com/docs/grafana/latest/developers/plugins/).

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ datasources:
 ## How to build this datasource
 You will need to install [Node.js](https://nodejs.org/en/), [Yarn](https://yarnpkg.com/), [Go](https://golang.org/), and [Mage](https://magefile.org/) first.
 1. `yarn install --frozen-lockfile`
-1. `rm -rf node_modules/@grafana/data/node_modules`
-1. `npm run build`
+1. `yarn dev`
 1. (Optional) `mage -v buildAll` This is optional if you need backend plugins for other platforms.
 1. [Sign the plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/), or configure Grafana to [load the unsigned plugin](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins).
 1. The compiled plugin should be in `dist/` directory.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ datasources:
 ## How to build this datasource
 You will need to install [Node.js](https://nodejs.org/en/), [Yarn](https://yarnpkg.com/), [Go](https://golang.org/), and [Mage](https://magefile.org/) first.
 1. `yarn install --frozen-lockfile`
-1. `yarn dev` will build your frontend changes
+1. `yarn dev` -- will build the frontend changes
 1. `mage build:backend` -- will build the backend changes
-1. (Optional) `mage -v buildAll` This is optional if you need backend plugins for other platforms.
+1. (Optional) `mage -v buildAll` -- this is optional if you need backend plugins for other platforms
 1. [Sign the plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/), or configure Grafana to [load the unsigned plugin](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins).
 1. The compiled plugin should be in `dist/` directory.
 1. You can install by following the [install Grafana plugins docs page](https://grafana.com/docs/grafana/latest/plugins/installation/).

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ datasources:
 ## How to build this datasource
 You will need to install [Node.js](https://nodejs.org/en/), [Yarn](https://yarnpkg.com/), [Go](https://golang.org/), and [Mage](https://magefile.org/) first.
 1. `yarn install --frozen-lockfile`
-1. `yarn dev` -- will build the frontend changes
-1. `mage build:backend` -- will build the backend changes
-1. (Optional) `mage -v buildAll` -- this is optional if you need backend plugins for other platforms
+1. `yarn dev` — will build the frontend changes
+1. `mage build:backend` — will build the backend changes
+1. (Optional) `mage -v buildAll` — this is optional if you need backend plugins for other platforms
 1. [Sign the plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/), or configure Grafana to [load the unsigned plugin](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins).
 1. The compiled plugin should be in `dist/` directory.
 1. You can install by following the [install Grafana plugins docs page](https://grafana.com/docs/grafana/latest/plugins/installation/).


### PR DESCRIPTION
I saw that the steps to build plugin is not straightforward. Is it possible to add these to the README file?