### PR TITLE
Support long query when using regex with variable

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -224,6 +224,9 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     } as unknown) as DataQueryRequest).pipe(
       map(res => {
         const first = res.data[0] as DataFrame;
+        if (!first || !first.length) {
+          return [];
+        }
         const vals = first.fields[0]?.values;
         if (vals) {
           return vals.toArray(); //


### PR DESCRIPTION
## Why is this change required?
- `Cannot read property 'fields' of undefined` if a variable depends on
a long query and a regex filter
- This should fix #41

## How does this change solve the issue?
- If there is no data (a long query is still running), then return a
blank array

## Does this commit cause any expected behaviors to change? If so, what?
- None


---
Tests
---
- Tested in my local Grafana setup (Docker; Grafana v7.3.6 (ea06633c34))