### PR TITLE
Bug/no quote around measure

### DIFF
--- a/pkg/timestream/macros_test.go
+++ b/pkg/timestream/macros_test.go
@@ -48,8 +48,8 @@ func TestInterpolate(t *testing.T) {
 	})
 
 	t.Run("using templates", func(t *testing.T) {
-		sqltxt := `SELECT $__measure FROM $__database.$__table LIMIT 10`
-		expect := `SELECT measure FROM ddb.table LIMIT 10`
+		sqltxt := `SELECT '$__measure' FROM $__database.$__table LIMIT 10`
+		expect := `SELECT 'measure' FROM ddb.table LIMIT 10`
 
 		query := models.QueryModel{
 			TimeRange: timeRange,

--- a/src/SchemaInfo.ts
+++ b/src/SchemaInfo.ts
@@ -244,7 +244,7 @@ export class SchemaInfo {
       const dims: KeyValue<string[]> = {};
       this.measures = info.map(v => {
         dims[v.name] = v.dimensions;
-        return { label: `${v.name} (${v.type})`, value: `"${v.name}"` };
+        return { label: `${v.name} (${v.type})`, value: `${v.name}` };
       });
       this.dimensions = dims;
       if (this.templateSrv) {


### PR DESCRIPTION
## Why is this change required?
- Based on an example we want users to put quotes around `$__measure`
themselves like `'$__measure'`
- This should fix the problem reported in the latest comment of #30 

## Does this commit cause any expected behaviors to change? If so, what?
- None

---
Tests
---
- Tests with Docker and Grafana v7.3.6 (ea06633c34)