### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Timestream datasource plugin provides a support for [Amazon Timestream](http
 
 Please add feedback to the [issues](https://github.com/grafana/timestream-datasource/issues) folder, and we will follow up shortly.  Be sure to include version information for both grafana and the installed plugin.
 
-The production plugins can be downloaded from [the Timestream plugin page](https://grafana.com/grafana/plugins/grafana-timestream-datasource/installation).
+The production plugins can be downloaded from [the Timestream plugin page](https://grafana.com/grafana/plugins/grafana-timestream-datasource/).
 
 For configuration options, see: [src/README.md](src/README.md)
 

--- a/src/README.md
+++ b/src/README.md
@@ -90,3 +90,7 @@ datasources:
       accessKey: '<your access key>'
       secretKey: '<your secret key>'
 ```
+
+### Sample Dashboards
+
+This plugin contains two sample dashboards. Please consult the [Sample Application section](https://docs.aws.amazon.com/timestream/latest/developerguide/Grafana.html#Grafana.sample-app) in the official Timestream doc to set them up.

--- a/src/README.md
+++ b/src/README.md
@@ -91,6 +91,6 @@ datasources:
       secretKey: '<your secret key>'
 ```
 
-### Sample Dashboards
+### Sample Dashboard
 
-This plugin contains two sample dashboards. Please consult the [Sample Application section](https://docs.aws.amazon.com/timestream/latest/developerguide/Grafana.html#Grafana.sample-app) in the official Timestream doc to set them up.
+This plugin contains one sample dashboard. Please consult the [Sample Application section](https://docs.aws.amazon.com/timestream/latest/developerguide/Grafana.html#Grafana.sample-app) in the official Timestream doc to set it up.


### PR DESCRIPTION
## Why is this change required?
- Broken link in the dev readme
- Missing instruction to setup sample dashboard in the plugin readme