### PR TITLE
Combine all timeseries results from multiple response pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## v1.3.0
-- Use new authentication methods
+- fix bug with supporting multi-page timeseries results
+- Use a shared authentication library and UI component
 - Bump minimum grafana runtime to 7.4
 
 ## v1.2.0

--- a/drone.cue
+++ b/drone.cue
@@ -1,6 +1,0 @@
-spec: {
-  kind: "grafana-plugin"
-  slug: "timestream-datasource"
-  name: "AWS Timestream Datasource"
-  hasBackend: true
-}

--- a/src/appendFrames.ts
+++ b/src/appendFrames.ts
@@ -1,0 +1,68 @@
+import { ArrayVector, DataFrame, formatLabels, MutableDataFrame } from '@grafana/data';
+
+export function getSchemaKey(frame: DataFrame): string {
+  let key = frame.refId + '/' + frame.fields.length;
+  for (const f of frame.fields) {
+    key += '|' + f.name + ':' + f.type;
+    if (f.labels) {
+      key += formatLabels(f.labels);
+    }
+  }
+  return key;
+}
+
+// TODO: this could likley use the builtin merge transformer, however it was behaving weirdly
+// with arrow time fields ;(
+export function appendMatchingFrames(prev: DataFrame[], b: DataFrame[]): DataFrame[] {
+  const byKey = new Map<string, MutableDataFrame>();
+  const out: DataFrame[] = [];
+  for (const f of prev) {
+    if (!f.length) {
+      continue;
+    }
+
+    const key = getSchemaKey(f);
+    if (f instanceof MutableDataFrame) {
+      byKey.set(key, f);
+      out.push(f);
+    } else {
+      const frame = new MutableDataFrame();
+      frame.meta = f.meta;
+      frame.name = f.name;
+      frame.refId = f.refId;
+
+      // Arrow frames are not appending properly ???
+      for (const field of f.fields) {
+        const buffer: any[] = [];
+        for (let i = 0; i < f.length; i++) {
+          buffer.push(field.values.get(i));
+        }
+        frame.addField({
+          ...field,
+          values: new ArrayVector(buffer),
+        });
+      }
+
+      byKey.set(key, frame);
+      out.push(frame);
+    }
+  }
+
+  for (const f of b) {
+    if (!f.length) {
+      continue;
+    }
+    const key = getSchemaKey(f);
+    const old = byKey.get(key);
+    if (old) {
+      for (let i = 0; i < f.length; i++) {
+        for (let idx = 0; idx < old.fields.length; idx++) {
+          old.fields[idx].values.add(f.fields[idx].values.get(i));
+        }
+      }
+    } else {
+      out.push(f);
+    }
+  }
+  return out;
+}

--- a/src/requestLooper.ts
+++ b/src/requestLooper.ts
@@ -58,12 +58,13 @@ export function getRequestLooper<T extends DataQuery = DataQuery>(
 
         const data = options.process(tracker, rsp.data, !!!nextQuery);
 
+        // Show the spinner or streaming (streaming will show data)
         if (checkstate) {
           if (nextQuery) {
-            if (!data.length || data[0].length < 1) {
-              loadingState = LoadingState.Loading;
-            } else {
+            if (data.length && data[0].length) {
               loadingState = LoadingState.Streaming;
+            } else {
+              loadingState = LoadingState.Loading;
             }
           } else {
             loadingState = LoadingState.Done;


### PR DESCRIPTION
Currently when timeseries results require multiple pages to return all data, only the last frame is returned (and it is often empty!) so the result is showing no data :face_with_head_bandage: 

This PR changes the multi-page handling to make sure results from multiple pages are supported.