### PR TITLE
Add `eu-central-1` as supported region

### DIFF
--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1,1 +1,1 @@
-export const standardRegions = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1'];
+export const standardRegions = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1', 'eu-central-1'];


### PR DESCRIPTION
`eu-central-1` supported since April 23rd 2021
- https://aws.amazon.com/about-aws/whats-new/2021/04/amazon-timestream-is-now-available-in-europe-frankfurt-region/?nc1=h_ls