### PR TITLE
POC: support paging with streaming queries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,16 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-        
         {
-            "name": "Launch",
+            "name": "Run standalone plugin",
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${fileDirname}",
+            "program": "${workspaceFolder}/pkg/main.go",
             "env": {},
-            "args": []
+            "args": [
+                "--standalone=true",
+            ]
         }
     ]
 }

--- a/pkg/timestream/executor.go
+++ b/pkg/timestream/executor.go
@@ -12,8 +12,9 @@ import (
 )
 
 // ExecuteQuery -- run a query
-func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunner, settings models.DatasourceSettings) (dr backend.DataResponse) {
+func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunner, settings models.DatasourceSettings) (dr backend.DataResponse, nextToken string) {
 	dr = backend.DataResponse{}
+	nextToken = ""
 
 	raw, err := Interpolate(query, settings)
 	if err != nil {
@@ -58,6 +59,7 @@ func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunn
 
 	// Apply the timing info
 	meta := frame.Meta.Custom.(*models.TimestreamCustomMeta)
+	nextToken = meta.NextToken
 	if meta.NextToken == "" {
 		meta.FinishTime = finish
 	}

--- a/pkg/timestream/executor_test.go
+++ b/pkg/timestream/executor_test.go
@@ -16,7 +16,7 @@ import (
 
 func runTest(t *testing.T, name string) *backend.DataResponse {
 	mockClient := &MockClient{testFileName: name}
-	dr := ExecuteQuery(context.Background(), models.QueryModel{}, mockClient, models.DatasourceSettings{})
+	dr, _ := ExecuteQuery(context.Background(), models.QueryModel{}, mockClient, models.DatasourceSettings{})
 
 	// Remove changable fields
 	for _, frame := range dr.Frames {

--- a/pkg/timestream/runningQuery.go
+++ b/pkg/timestream/runningQuery.go
@@ -2,20 +2,24 @@ package timestream
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/timestream-datasource/pkg/models"
 )
 
 type openQuery struct {
-	nextToken string
-	query     models.QueryModel
-	runner    queryRunner
+	queryId string
+	query   *models.QueryModel
+	ds      *timestreamDS
 }
 
-func (ds *openQuery) doStream(ctx context.Context, sender *backend.StreamSender) error {
-	timer := time.NewTimer(time.Second * 10)
+func (q *openQuery) doStream(ctx context.Context, sender *backend.StreamSender) error {
+	backend.Logger.Info("Starting stream for", "queryId", q.queryId, "token", q.query.NextToken)
+	timer := time.NewTimer(time.Second * 2)
 
 	for {
 		select {
@@ -23,7 +27,26 @@ func (ds *openQuery) doStream(ctx context.Context, sender *backend.StreamSender)
 			backend.Logger.Info("stop streaming (context canceled)")
 			return nil
 		case <-timer.C:
-			backend.Logger.Info("TODO... run query!", "token", ds.nextToken)
+			backend.Logger.Info("TODO... run query!", "token", q.query.NextToken)
+
+			dr, nextToken := ExecuteQuery(ctx, *q.query, q.ds.Runner, q.ds.Settings)
+			if dr.Error != nil {
+				backend.Logger.Error("error running streaming query", "query", q.queryId, "err", dr.Error)
+				return nil
+			}
+
+			// Send each frame
+			for _, frame := range dr.Frames {
+				err := sender.SendFrame(frame, data.IncludeAll)
+				if err != nil {
+					log.DefaultLogger.Error(fmt.Sprintf("unable to send message: %s", err.Error()))
+				}
+			}
+
+			if nextToken == "" {
+				return nil // done -- TODO? tell the frontend the query is done
+			}
+			q.query.NextToken = nextToken
 		}
 	}
 }

--- a/pkg/timestream/runningQuery.go
+++ b/pkg/timestream/runningQuery.go
@@ -1,0 +1,29 @@
+package timestream
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/timestream-datasource/pkg/models"
+)
+
+type openQuery struct {
+	nextToken string
+	query     models.QueryModel
+	runner    queryRunner
+}
+
+func (ds *openQuery) doStream(ctx context.Context, sender *backend.StreamSender) error {
+	timer := time.NewTimer(time.Second * 10)
+
+	for {
+		select {
+		case <-ctx.Done():
+			backend.Logger.Info("stop streaming (context canceled)")
+			return nil
+		case <-timer.C:
+			backend.Logger.Info("TODO... run query!", "token", ds.nextToken)
+		}
+	}
+}

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -108,11 +108,11 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
             if (meta && meta.nextToken) {
               queryId = meta.queryId;
 
-              return {
-                refId: first.refId,
-                rawQuery: first.meta?.executedQueryString,
-                nextToken: meta.nextToken,
-              } as TimestreamQuery;
+              // return {
+              //   refId: first.refId,
+              //   rawQuery: first.meta?.executedQueryString,
+              //   nextToken: meta.nextToken,
+              // } as TimestreamQuery;
             }
           }
           return undefined;


### PR DESCRIPTION
We currently support paging by having the client submit additional requests over HTTP when a `nextToken` exists -- this PR explores how we could service the requests with a continuous stream from the backend.  This uses the new live features in grafana 8

TODO?
- should this be optional, or the standard way to support multiple pages?
- this using the standard StreamingDataFrame processing -- do we need anything different?