### PR TITLE
add macros for raw values of interval, from, to

### DIFF
--- a/pkg/timestream/macros.go
+++ b/pkg/timestream/macros.go
@@ -10,7 +10,10 @@ import (
 )
 
 const timeFilter = `\$__timeFilter`
+const timeFromStr = `$__time_from_raw_ms`
+const timeToStr = `$__time_to_raw_ms`
 const intervalStr = `$__interval_ms`
+const intervalRawStr = `$__interval_raw_ms`
 const nowStr = `$__now_ms`
 
 // WHERE time > from_unixtime(unixtime)
@@ -45,12 +48,31 @@ func Interpolate(query models.QueryModel, settings models.DatasourceSettings) (s
 		txt = timeFilterExp.ReplaceAllString(txt, replacement)
 	}
 
+	if strings.Contains(txt, timeFromStr) {
+		timeRange := query.TimeRange
+		from := int64(timeRange.From.UnixNano() / 1e6)
+		replacement := fmt.Sprintf("%d", from)
+		txt = strings.ReplaceAll(txt, timeFromStr, replacement)
+	}
+
+	if strings.Contains(txt, timeToStr) {
+		timeRange := query.TimeRange
+		to := int64(timeRange.To.UnixNano() / 1e6)
+		replacement := fmt.Sprintf("%d", to)
+		txt = strings.ReplaceAll(txt, timeToStr, replacement)
+	}
+
 	if strings.Contains(txt, intervalStr) {
 		replacement := fmt.Sprintf("%dms", query.Interval.Milliseconds())
 		if replacement == "0ms" {
 			replacement = "{!invalid interval=" + query.Interval.String() + "!}"
 		}
 		txt = strings.ReplaceAll(txt, intervalStr, replacement)
+	}
+
+	if strings.Contains(txt, intervalRawStr) {
+		replacement := fmt.Sprintf("%d", query.Interval.Milliseconds())
+		txt = strings.ReplaceAll(txt, intervalRawStr, replacement)
 	}
 
 	if strings.Contains(txt, nowStr) {

--- a/pkg/timestream/macros.go
+++ b/pkg/timestream/macros.go
@@ -10,8 +10,8 @@ import (
 )
 
 const timeFilter = `\$__timeFilter`
-const timeFromStr = `$__time_from`
-const timeToStr = `$__time_to`
+const timeFromStr = `$__timeFrom`
+const timeToStr = `$__timeTo`
 const intervalStr = `$__interval_ms`
 const intervalRawStr = `$__interval_raw_ms`
 const nowStr = `$__now_ms`

--- a/pkg/timestream/macros.go
+++ b/pkg/timestream/macros.go
@@ -10,8 +10,8 @@ import (
 )
 
 const timeFilter = `\$__timeFilter`
-const timeFromStr = `$__time_from_raw_ms`
-const timeToStr = `$__time_to_raw_ms`
+const timeFromStr = `$__time_from`
+const timeToStr = `$__time_to`
 const intervalStr = `$__interval_ms`
 const intervalRawStr = `$__interval_raw_ms`
 const nowStr = `$__now_ms`

--- a/pkg/timestream/macros_test.go
+++ b/pkg/timestream/macros_test.go
@@ -95,67 +95,48 @@ func TestInterpolate(t *testing.T) {
 	})
 
 	t.Run("using timeFrom", func(t *testing.T) {
-		sqltxt := `$__time_from_raw_ms`
+		sqltxt := `WHERE TIME > from_milliseconds($__time_from)`
+		expect := `WHERE TIME > from_milliseconds(1500376552001)`
+
 		query := models.QueryModel{
 			TimeRange: timeRange,
 			RawQuery:  sqltxt,
 		}
+
 		text, _ := Interpolate(query, models.DatasourceSettings{})
-		expect := int64(1500376552001)
-
-		var numtext int64
-		_, e := fmt.Sscan(text, &numtext)
-
-		if e != nil {
-			t.Fatalf(e.Error())
-		}
-
-		if !cmp.Equal(numtext, expect) {
-			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		if diff := cmp.Diff(text, expect); diff != "" {
+			t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 		}
 	})
 
 	t.Run("using timeTo", func(t *testing.T) {
-		sqltxt := `$__time_to_raw_ms`
+		sqltxt := `WHERE TIME < from_milliseconds($__time_to)`
+		expect := `WHERE TIME < from_milliseconds(1500376552002)`
+
 		query := models.QueryModel{
 			TimeRange: timeRange,
 			RawQuery:  sqltxt,
 		}
+
 		text, _ := Interpolate(query, models.DatasourceSettings{})
-		expect := int64(1500376552002)
-
-		var numtext int64
-		_, e := fmt.Sscan(text, &numtext)
-
-		if e != nil {
-			t.Fatalf(e.Error())
-		}
-
-		if !cmp.Equal(numtext, expect) {
-			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		if diff := cmp.Diff(text, expect); diff != "" {
+			t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 		}
 	})
 
 	t.Run("using raw interval", func(t *testing.T) {
-		sqltxt := `$__interval_raw_ms`
-		expect := 60000
+		sqltxt := `rate(input) * $__interval_raw_ms`
+		expect := `rate(input) * 60000`
 
 		query := models.QueryModel{
 			TimeRange: timeRange,
 			RawQuery:  sqltxt,
 			Interval:  time.Minute,
 		}
+
 		text, _ := Interpolate(query, models.DatasourceSettings{})
-
-		var numtext int
-		_, e := fmt.Sscan(text, &numtext)
-
-		if e != nil {
-			t.Fatalf(e.Error())
-		}
-
-		if !cmp.Equal(numtext, expect) {
-			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		if diff := cmp.Diff(text, expect); diff != "" {
+			t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 		}
 	})
 }

--- a/pkg/timestream/macros_test.go
+++ b/pkg/timestream/macros_test.go
@@ -93,4 +93,69 @@ func TestInterpolate(t *testing.T) {
 			t.Fatalf("Result above tolerated precision %d : %d, %d", precision, numtext, expect)
 		}
 	})
+
+	t.Run("using timeFrom", func(t *testing.T) {
+		sqltxt := `$__time_from_raw_ms`
+		query := models.QueryModel{
+			TimeRange: timeRange,
+			RawQuery:  sqltxt,
+		}
+		text, _ := Interpolate(query, models.DatasourceSettings{})
+		expect := int64(1500376552001)
+
+		var numtext int64
+		_, e := fmt.Sscan(text, &numtext)
+
+		if e != nil {
+			t.Fatalf(e.Error())
+		}
+
+		if !cmp.Equal(numtext, expect) {
+			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		}
+	})
+
+	t.Run("using timeTo", func(t *testing.T) {
+		sqltxt := `$__time_to_raw_ms`
+		query := models.QueryModel{
+			TimeRange: timeRange,
+			RawQuery:  sqltxt,
+		}
+		text, _ := Interpolate(query, models.DatasourceSettings{})
+		expect := int64(1500376552002)
+
+		var numtext int64
+		_, e := fmt.Sscan(text, &numtext)
+
+		if e != nil {
+			t.Fatalf(e.Error())
+		}
+
+		if !cmp.Equal(numtext, expect) {
+			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		}
+	})
+
+	t.Run("using raw interval", func(t *testing.T) {
+		sqltxt := `$__interval_raw_ms`
+		expect := 60000
+
+		query := models.QueryModel{
+			TimeRange: timeRange,
+			RawQuery:  sqltxt,
+			Interval:  time.Minute,
+		}
+		text, _ := Interpolate(query, models.DatasourceSettings{})
+
+		var numtext int
+		_, e := fmt.Sscan(text, &numtext)
+
+		if e != nil {
+			t.Fatalf(e.Error())
+		}
+
+		if !cmp.Equal(numtext, expect) {
+			t.Fatalf("Result does not equal expected: %d, %d", numtext, expect)
+		}
+	})
 }

--- a/pkg/timestream/macros_test.go
+++ b/pkg/timestream/macros_test.go
@@ -95,7 +95,7 @@ func TestInterpolate(t *testing.T) {
 	})
 
 	t.Run("using timeFrom", func(t *testing.T) {
-		sqltxt := `WHERE TIME > from_milliseconds($__time_from)`
+		sqltxt := `WHERE TIME > from_milliseconds($__timeFrom)`
 		expect := `WHERE TIME > from_milliseconds(1500376552001)`
 
 		query := models.QueryModel{
@@ -110,7 +110,7 @@ func TestInterpolate(t *testing.T) {
 	})
 
 	t.Run("using timeTo", func(t *testing.T) {
-		sqltxt := `WHERE TIME < from_milliseconds($__time_to)`
+		sqltxt := `WHERE TIME < from_milliseconds($__timeTo)`
 		expect := `WHERE TIME < from_milliseconds(1500376552002)`
 
 		query := models.QueryModel{

--- a/src/README.md
+++ b/src/README.md
@@ -34,7 +34,10 @@ Macro example | Description
 *$__table* | Will specify the selected database.  This may use the default from the datasource config, or the explicit value from the query editor.
 *$__measure* | Will specify the selected measure.  This may use the default from the datasource config, or the explicit value from the query editor.
 *$__timeFilter* | Will be replaced by an expression that limits the time to the dashboard range
-*$__interval_ms* | Will be replaced by a number that represents the amount of time a single pixel in the graph should cover
+*$__timeFrom* | Will be replaced by the number in milliseconds at the start of the dashboard range.
+*$__timeTo* | Will be replaced by the number in milliseconds at the end of the dashboard range.
+*$__interval_ms* | Will be replaced by a time that represents the amount of time a single pixel in the graph should cover.
+*$__interval_raw_ms* | Will be replaced by the number that represents the amount of time in milliseconds a single pixel in the graph should cover. This can be used in calculations and will not be treated as a time.
 
 
 ## Using Variables in Queries


### PR DESCRIPTION
Hi there,

When using the Grafana plugin, we sometimes have to do some string replacement and casting on the current interval and timeFilter macros in order to use the raw values for calculations.

It would be nicer for us if we could have macros to access those values directly like this PR allows.

Happy to change anything that doesn't fit with your macro standards. 