### PR TITLE
Chore: TS fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@grafana/e2e": "7.5.1",
     "@grafana/e2e-selectors": "7.5.1",
     "@types/lodash": "latest",
+    "tslib": "2.3.1",
     "cypress": "6.4.0"
   }
 }

--- a/src/appendFrames.ts
+++ b/src/appendFrames.ts
@@ -1,6 +1,6 @@
 import { ArrayVector, DataFrame, formatLabels, MutableDataFrame } from '@grafana/data';
 
-export function getSchemaKey(frame: DataFrame): string {
+function getSchemaKey(frame: DataFrame): string {
   let key = frame.refId + '/' + frame.fields.length;
   for (const f of frame.fields) {
     key += '|' + f.name + ':' + f.type;

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -24,7 +24,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
   componentDidMount = async () => {
     const d = await getDataSourceSrv().get(this.props.options.name);
     const { options } = this.props;
-    const ds = d as DataSource;
+    const ds = (d as unknown) as DataSource;
     const query = {
       refId: 'X',
       database: options.jsonData.defaultDatabase,

--- a/src/components/Forms.tsx
+++ b/src/components/Forms.tsx
@@ -16,14 +16,3 @@ export const QueryField: FunctionComponent<Partial<Props>> = ({ label, labelWidt
     {children}
   </>
 );
-
-export const QueryInlineField: FunctionComponent<Props> = ({ ...props }) => {
-  return (
-    <div className={'gf-form-inline'}>
-      <QueryField {...props} />
-      <div className="gf-form gf-form--grow">
-        <div className="gf-form-label gf-form-label--grow" />
-      </div>
-    </div>
-  );
-};

--- a/src/components/MetaInspector.tsx
+++ b/src/components/MetaInspector.tsx
@@ -1,9 +1,12 @@
 import React, { PureComponent } from 'react';
-import { MetadataInspectorProps, DataFrame } from '@grafana/data';
-import { DataSource } from '../DataSource';
+import { MetadataInspectorProps, DataFrame, DataSourceApi } from '@grafana/data';
 import { TimestreamQuery, TimestreamOptions } from '../types';
 
-export type Props = MetadataInspectorProps<DataSource, TimestreamQuery, TimestreamOptions>;
+export type Props = MetadataInspectorProps<
+  DataSourceApi<TimestreamQuery, TimestreamOptions>,
+  TimestreamQuery,
+  TimestreamOptions
+>;
 
 export class MetaInspector extends PureComponent<Props> {
   state = { index: 0 };

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { DataSourceApi, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from '../DataSource';
 import { TimestreamQuery, TimestreamOptions, QueryType } from '../types';
 import { getTemplateSrv } from '@grafana/runtime';
@@ -10,7 +10,7 @@ import { Segment, SegmentAsync, InlineFormLabel, CodeEditor } from '@grafana/ui'
 import { sampleQueries, queryTypes } from './samples';
 import { SchemaInfo } from 'SchemaInfo';
 
-type Props = QueryEditorProps<DataSource, TimestreamQuery, TimestreamOptions>;
+type Props = QueryEditorProps<DataSourceApi<TimestreamQuery, TimestreamOptions>, TimestreamQuery, TimestreamOptions>;
 interface State {
   schema?: SchemaInfo;
 
@@ -22,8 +22,8 @@ export class QueryEditor extends PureComponent<Props, State> {
 
   componentDidMount = () => {
     const { datasource, query } = this.props;
-
-    const schema = new SchemaInfo(datasource, query, getTemplateSrv());
+    const ds = (datasource as unknown) as DataSource;
+    const schema = new SchemaInfo(ds, query, getTemplateSrv());
     this.setState({ schema: schema, schemaState: schema.state });
 
     schema.preload().then((v) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,14 @@
-import { DataSourcePlugin } from '@grafana/data';
+import { DataSourceApi, DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './DataSource';
 import { QueryEditor, ConfigEditor } from './components';
 import { TimestreamQuery, TimestreamOptions } from './types';
 import { MetaInspector } from 'components/MetaInspector';
 
-export const plugin = new DataSourcePlugin<DataSource, TimestreamQuery, TimestreamOptions>(DataSource)
+export const plugin = new DataSourcePlugin<
+  DataSourceApi<TimestreamQuery, TimestreamOptions>,
+  TimestreamQuery,
+  TimestreamOptions
+>(DataSource as any)
   .setConfigEditor(ConfigEditor)
   .setMetadataInspector(MetaInspector)
   .setQueryEditor(QueryEditor);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12895,6 +12895,11 @@ tslib@2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
+tslib@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"


### PR DESCRIPTION
This PR cleans up a bit of unused code and fix Typescript errors that were being thrown when running the plugin with `yarn watch`. The goal is not to give have a final solution for the TS errors since the plan is to [refactor the plugin in the future](https://github.com/grafana/grafana-aws-sdk/issues/28). 