### PR TITLE
chore: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a bug you found when using this plugin
+labels: 'type: bug'
+---
+
+<!--
+Please use this template to create your bug report. By providing as much info as possible you help us understand the issue, reproduce it and resolve it for you quicker. Therefore, take a couple of extra minutes to make sure you have provided all info needed.
+
+PROTIP: record your screen and attach it as a gif to showcase the issue.
+
+- Use query inspector to troubleshoot issues: https://bit.ly/2XNF6YS
+- How to record and attach gif: https://bit.ly/2Mi8T6K
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+<!--
+Example:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Grafana version:
+- Plugin version:
+- OS Grafana is installed on:
+- User OS & Browser:
+- Others:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/grafana/timestream-datasource/discussions/new
+    about: Discuss ideas for new features or changes
+  - name: Questions & Help
+    url: https://community.grafana.com
+    about: Please ask and answer questions here


### PR DESCRIPTION
Taking inspiration from the [Grafana issue template](https://github.com/grafana/grafana/tree/main/.github/ISSUE_TEMPLATE), add issue template for the project:

- Bug report template
- Feature requests go to GH discussions
- Questions are directed to the community site