### PR TITLE
Update changelog and bump version up to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.0
+
+- Add macros for raw values of interval, from, to [#98](https://github.com/grafana/timestream-datasource/pull/98)
+- Quote and join multiple variables [#118](https://github.com/grafana/timestream-datasource/pull/118)
+- Add stats for bytes metered and scanned [#110](https://github.com/grafana/timestream-datasource/pull/110)
+
+## v1.3.3
+
+- Support for multiple timeseries columns
+- Improved support for custom endpoint
+
 ## v1.3.2
+
 - Adding eu-central-1 region
 - renamed "master" branch to "main"
 - build with Golang 1.6
 
 ## v1.3.1
-- Execute each query in its own request, this will support multiple queries that 
+
+- Execute each query in its own request, this will support multiple queries that
   require multiple pages to complete
 - Upgrade shared authenticaiton library
 - Bump minimum grafana runtime to 7.5
 
 ## v1.3.0
+
 - fix bug with supporting multi-page timeseries results
 - Use a shared authentication library and UI component
 - Bump minimum grafana runtime to 7.4
 
 ## v1.2.0
-- Support $__timefilter on armhf (#52, @mg-arne)
-- Add $__now_ms macro (#49, @squalou)
+
+- Support $\_\_timefilter on armhf (#52, @mg-arne)
+- Add $\_\_now_ms macro (#49, @squalou)
 - Fixed region picker default values
 
 ## v1.1.2
+
 - Fix template variable queries
 - Only show valid regions
 
 ## v1.1.1
+
 - Avoid double escaping
 - support template variables in query
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "1.3.2-dev",
+  "version": "1.4.0",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "rm -rf dist && npx grafana-toolkit plugin:build && mage build:backend",


### PR DESCRIPTION
We'd like to make a release, interestingly the changelog changes from 1.3 do not appear in main, I'm not sure if that means they were never released or if they were just not properly merged? But either way I copied over the changelog changes as well as added new ones. Hopefully that was the right call!