### PR TITLE
Replace  $__interval variable

### DIFF
--- a/pkg/timestream/macros.go
+++ b/pkg/timestream/macros.go
@@ -12,6 +12,7 @@ import (
 const timeFilter = `\$__timeFilter`
 const timeFromStr = `$__timeFrom`
 const timeToStr = `$__timeTo`
+const intervalStrAlias = `$__interval`
 const intervalStr = `$__interval_ms`
 const intervalRawStr = `$__interval_raw_ms`
 const nowStr = `$__now_ms`
@@ -62,17 +63,19 @@ func Interpolate(query models.QueryModel, settings models.DatasourceSettings) (s
 		txt = strings.ReplaceAll(txt, timeToStr, replacement)
 	}
 
-	if strings.Contains(txt, intervalStr) {
+	if strings.Contains(txt, intervalRawStr) {
+		replacement := fmt.Sprintf("%d", query.Interval.Milliseconds())
+		txt = strings.ReplaceAll(txt, intervalRawStr, replacement)
+	}
+
+	if strings.Contains(txt, intervalStr) || strings.Contains(txt, intervalStrAlias) {
 		replacement := fmt.Sprintf("%dms", query.Interval.Milliseconds())
 		if replacement == "0ms" {
 			replacement = "{!invalid interval=" + query.Interval.String() + "!}"
 		}
 		txt = strings.ReplaceAll(txt, intervalStr, replacement)
-	}
-
-	if strings.Contains(txt, intervalRawStr) {
-		replacement := fmt.Sprintf("%d", query.Interval.Milliseconds())
-		txt = strings.ReplaceAll(txt, intervalRawStr, replacement)
+		// replace $__interval too
+		txt = strings.ReplaceAll(txt, intervalStrAlias, replacement)
 	}
 
 	if strings.Contains(txt, nowStr) {

--- a/pkg/timestream/macros.go
+++ b/pkg/timestream/macros.go
@@ -74,7 +74,6 @@ func Interpolate(query models.QueryModel, settings models.DatasourceSettings) (s
 			replacement = "{!invalid interval=" + query.Interval.String() + "!}"
 		}
 		txt = strings.ReplaceAll(txt, intervalStr, replacement)
-		// replace $__interval too
 		txt = strings.ReplaceAll(txt, intervalStrAlias, replacement)
 	}
 

--- a/pkg/timestream/macros_test.go
+++ b/pkg/timestream/macros_test.go
@@ -48,6 +48,21 @@ func TestInterpolate(t *testing.T) {
 		}
 	})
 
+	t.Run("using interval alias", func(t *testing.T) {
+		sqltxt := `GROUP BY $__interval TIMESERIES`
+		expect := `GROUP BY 60000ms TIMESERIES`
+
+		query := models.QueryModel{
+			TimeRange: timeRange,
+			RawQuery:  sqltxt,
+			Interval:  time.Minute,
+		}
+		text, _ := Interpolate(query, models.DatasourceSettings{})
+		if diff := cmp.Diff(text, expect); diff != "" {
+			t.Fatalf("Result mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("using templates", func(t *testing.T) {
 		sqltxt := `SELECT '$__measure' FROM $__database.$__table LIMIT 10`
 		expect := `SELECT 'measure' FROM ddb.table LIMIT 10`


### PR DESCRIPTION
Fixes #100

TIL that the `$__interval` variable is replaced by default in the frontend when doing `interpolateTemplateVariables`. This does not work with alerting so Timestream removes these default template variables to do it in the backend instead. In any case, the `$__interval` alias (which is the same than `$__interval_ms`) was missing.

This is something that all the SQL data sources should do so I added an issue for this: https://github.com/grafana/grafana-aws-sdk/issues/44