### PR TITLE
chore: automate new issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+* @grafana/cloud-datasources

--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug you found when using this plugin
-labels: 'type: bug'
+labels: ["datasource/Timestream", "type/bug"]
 ---
 
 <!--

--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,0 +1,18 @@
+[   
+    {
+      "type": "label",
+      "name": "datasource/Timestream",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/97"
+      }
+    },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,21 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_commands

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -2,6 +2,8 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]    
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Added @grafana/cloud-datasources as codeowners
- Added default `datasource/Timestream` label for new bug reports

Currently, we automatically add the label `datasource/*` to new issues.
This PR uses the existing GH action already set up to additionally add them to our GH Projects board.

Ideally, this should be done without relying on the `datasource/*` label (since now we have two places where the label is defined: `issue_commands.json` and `1-bug_report.md`) but can use what we have in place for now and come up with another way of doing this later.

**TODO:**
Need to new secret to this repository called `GH_BOT_ACCESS_TOKEN` as it is required by this action to be able to work properly