### PR TITLE
GH action: ignore dependabot branches

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -3,7 +3,8 @@ on:
   issues:
     types: [labeled]
   pull_request:
-    types: [labeled]    
+    types: [labeled]   
+    branches-ignore: "dependabot/**" 
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR excludes dependabot/** branches from triggering commands.
It seems like due to security reasons secrets are not exposed to some types of pull requests.

Fixes https://github.com/grafana/timestream-datasource/issues/146 