### PR TITLE
Add test coverage github action

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2 # TODO: does this node setup need to happen each time we switch branches?
+      - uses: actions/setup-node@v2
         with:
           node-version: 12.x
           cache: yarn
       - name: yarn install for this PR
-        run: yarn install # TODO: do we need --frozen-lockfile? we are yarn install-ing again below
+        run: yarn install
 
       - name: Get coverage for this PR
         run: |
@@ -23,14 +23,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: main
-      - uses: actions/setup-node@v2 # TODO: does this node need to happen each time we switch branches?
-        with:
-          node-version: 12.x
-          cache: yarn
       - name: yarn install for main
         run: yarn install
 
-      - name: Get coverage on main # TODO: can consider if we should save this coverage as an artifact?
+      - name: Get coverage on main
         run: |
           go test -v -coverpkg=./... -coverprofile=profile.cov ./...
           echo "go-main-cov=$(go tool cover -func profile.cov | grep total: | awk '{print substr($NF,1,length($NF)-1)}')" >> $GITHUB_ENV


### PR DESCRIPTION
This github action does the following for pull requests:
* Checks out this PR's code
* Checks out code on main
* Calculates test coverage for each
* Leaves a comment on the PR with a test coverage report with the difference between PR coverage vs main coverage
* When commits are added to the PR, the existing comment should be updated with an up-to-date coverage report.

To do:
- [x] Backend coverage
- [x] Add frontend coverage
- [ ] Migrate this action to another repo so it can be referenced from other repos

I was very much inspired by the [guidelines defined by the Loki team](https://github.com/grafana/loki/issues/5344) but didn't use drone reports as was done in the [proposed solution](https://github.com/grafana/loki/pull/5357)... 

Contributes to https://github.com/grafana/cloud-data-sources/issues/5