### PR TITLE
Always apply double quotes to database and table name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/grafana/grafana-aws-sdk v0.10.1
 	github.com/grafana/grafana-plugin-sdk-go v0.125.0
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,10 @@ github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -815,6 +817,7 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/pkg/timestream/datasource.go
+++ b/pkg/timestream/datasource.go
@@ -233,8 +233,12 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 			return err
 		}
 		// TODO: Use API endpoint to list tables
+		dbName := opts.Database
+		if dbName[0] != '"' && dbName[len(opts.Database)-1] != '"' {
+			dbName = fmt.Sprintf(`"%s"`, dbName)
+		}
 		v, err := ds.Runner.runQuery(ctx, &timestreamquery.QueryInput{
-			QueryString: aws.String(fmt.Sprintf("SHOW TABLES FROM %s", opts.Database)),
+			QueryString: aws.String(fmt.Sprintf("SHOW TABLES FROM %s", dbName)),
 		})
 		if err != nil {
 			return err

--- a/pkg/timestream/datasource.go
+++ b/pkg/timestream/datasource.go
@@ -252,7 +252,7 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 			return err
 		}
 		v, err := ds.Runner.runQuery(ctx, &timestreamquery.QueryInput{
-			QueryString: aws.String(fmt.Sprintf("SHOW MEASURES FROM %s.%s", applyQuotesIfNeeded(opts.Database), opts.Table)),
+			QueryString: aws.String(fmt.Sprintf("SHOW MEASURES FROM %s.%s", applyQuotesIfNeeded(opts.Database), applyQuotesIfNeeded(opts.Table))),
 		})
 		if err != nil {
 			return err
@@ -267,9 +267,9 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 	return fmt.Errorf("unknown resource")
 }
 
-func applyQuotesIfNeeded(dbName string) string {
-	if dbName[0] != '"' && dbName[len(dbName)-1] != '"' {
-		dbName = fmt.Sprintf(`"%s"`, dbName)
+func applyQuotesIfNeeded(input string) string {
+	if input[0] != '"' && input[len(input)-1] != '"' {
+		input = fmt.Sprintf(`"%s"`, input)
 	}
-	return dbName
+	return input
 }

--- a/pkg/timestream/datasource.go
+++ b/pkg/timestream/datasource.go
@@ -233,12 +233,8 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 			return err
 		}
 		// TODO: Use API endpoint to list tables
-		dbName := opts.Database
-		if dbName[0] != '"' && dbName[len(opts.Database)-1] != '"' {
-			dbName = fmt.Sprintf(`"%s"`, dbName)
-		}
 		v, err := ds.Runner.runQuery(ctx, &timestreamquery.QueryInput{
-			QueryString: aws.String(fmt.Sprintf("SHOW TABLES FROM %s", dbName)),
+			QueryString: aws.String(fmt.Sprintf("SHOW TABLES FROM %s", applyQuotesIfNeeded(opts.Database))),
 		})
 		if err != nil {
 			return err
@@ -269,4 +265,11 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 		}
 	}
 	return fmt.Errorf("unknown resource")
+}
+
+func applyQuotesIfNeeded(dbName string) string {
+	if dbName[0] != '"' && dbName[len(dbName)-1] != '"' {
+		dbName = fmt.Sprintf(`"%s"`, dbName)
+	}
+	return dbName
 }

--- a/pkg/timestream/datasource.go
+++ b/pkg/timestream/datasource.go
@@ -252,7 +252,7 @@ func (ds *timestreamDS) CallResource(ctx context.Context, req *backend.CallResou
 			return err
 		}
 		v, err := ds.Runner.runQuery(ctx, &timestreamquery.QueryInput{
-			QueryString: aws.String(fmt.Sprintf("SHOW MEASURES FROM %s.%s", opts.Database, opts.Table)),
+			QueryString: aws.String(fmt.Sprintf("SHOW MEASURES FROM %s.%s", applyQuotesIfNeeded(opts.Database), opts.Table)),
 		})
 		if err != nil {
 			return err

--- a/pkg/timestream/datasource_test.go
+++ b/pkg/timestream/datasource_test.go
@@ -128,7 +128,7 @@ func TestCallResource(t *testing.T) {
 	}
 }
 
-func Test_runQuery_always_sends_db_name_with_quotes(t *testing.T) {
+func Test_runQuery_always_wraps_db_and_table_name_in_quotes(t *testing.T) {
 	testCases := []struct {
 		name, resource, requestBody, expectedQuery string
 	}{
@@ -149,7 +149,7 @@ func Test_runQuery_always_sends_db_name_with_quotes(t *testing.T) {
 		},
 		{
 			resource:      "measures",
-			requestBody:   `{"database":"\"db\"","table":"some_table_name"}`,
+			requestBody:   `{"database":"\"db\"","table":"\"some_table_name\""}`,
 			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
 		},
 		{
@@ -159,50 +159,7 @@ func Test_runQuery_always_sends_db_name_with_quotes(t *testing.T) {
 		},
 		{
 			resource:      "dimensions",
-			requestBody:   `{"database":"\"db\"","table":"some_table_name"}`,
-			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			mockRunner := &fakeRunner{output: &timestreamquery.QueryOutput{Rows: []*timestreamquery.Row{}}}
-
-			assert.NoError(t, (&timestreamDS{Runner: mockRunner}).CallResource(context.Background(),
-				&backend.CallResourceRequest{
-					Method: "POST",
-					Path:   test.resource,
-					Body:   []byte(test.requestBody),
-				}, &fakeSender{}))
-
-			require.Len(t, mockRunner.calls.runQuery, 1)
-			assert.Equal(t, &timestreamquery.QueryInput{QueryString: &test.expectedQuery}, mockRunner.calls.runQuery[0])
-		})
-	}
-}
-
-func Test_runQuery_always_sends_table_name_with_quotes(t *testing.T) {
-	testCases := []struct {
-		name, resource, requestBody, expectedQuery string
-	}{
-		{
-			resource:      "measures",
-			requestBody:   `{"database":"db","table":"some_table_name"}`,
-			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
-		},
-		{
-			resource:      "measures",
-			requestBody:   `{"database":"db","table":"\"some_table_name\""}`,
-			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
-		},
-		{
-			resource:      "dimensions",
-			requestBody:   `{"database":"db","table":"some_table_name"}`,
-			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
-		},
-		{
-			resource:      "dimensions",
-			requestBody:   `{"database":"db","table":"\"some_table_name\""}`,
+			requestBody:   `{"database":"\"db\"","table":"\"some_table_name\""}`,
 			expectedQuery: `SHOW MEASURES FROM "db"."some_table_name"`,
 		},
 	}

--- a/pkg/timestream/datasource_test.go
+++ b/pkg/timestream/datasource_test.go
@@ -133,37 +133,31 @@ func Test_runQuery_always_sends_db_name_with_quotes(t *testing.T) {
 		name, resource, requestBody, expectedQuery string
 	}{
 		{
-			name:          "tables: db name without quotes runs query with quoted db name",
 			resource:      "tables",
 			requestBody:   `{"database":"db"}`,
 			expectedQuery: `SHOW TABLES FROM "db"`,
 		},
 		{
-			name:          "tables: db name with quotes runs query with db name as-is",
 			resource:      "tables",
 			requestBody:   `{"database":"\"db\""}`,
 			expectedQuery: `SHOW TABLES FROM "db"`,
 		},
 		{
-			name:          "measures: db name without quotes runs query with quoted db name",
 			resource:      "measures",
 			requestBody:   `{"database":"db","table":"some_table_name"}`,
 			expectedQuery: `SHOW MEASURES FROM "db".some_table_name`,
 		},
 		{
-			name:          "measures: db name with quotes runs query with db name as-is",
 			resource:      "measures",
 			requestBody:   `{"database":"\"db\"","table":"some_table_name"}`,
 			expectedQuery: `SHOW MEASURES FROM "db".some_table_name`,
 		},
 		{
-			name:          "dimensions: db name without quotes runs query with quoted db name",
 			resource:      "dimensions",
 			requestBody:   `{"database":"db","table":"some_table_name"}`,
 			expectedQuery: `SHOW MEASURES FROM "db".some_table_name`,
 		},
 		{
-			name:          "dimensions: db name with quotes runs query with db name as-is",
 			resource:      "dimensions",
 			requestBody:   `{"database":"\"db\"","table":"some_table_name"}`,
 			expectedQuery: `SHOW MEASURES FROM "db".some_table_name`,

--- a/pkg/timestream/datasource_test.go
+++ b/pkg/timestream/datasource_test.go
@@ -128,7 +128,7 @@ func TestCallResource(t *testing.T) {
 	}
 }
 
-func Test_queries_called_with_db_name_quoted(t *testing.T) {
+func Test_runQuery_always_sends_db_name_with_quotes(t *testing.T) {
 	t.Run("db name provided without quotes runs query with quoted db name", func(t *testing.T) {
 		mockRunner := &fakeRunner{output: &timestreamquery.QueryOutput{Rows: []*timestreamquery.Row{}}}
 		ts := &timestreamDS{Runner: mockRunner}
@@ -158,5 +158,4 @@ func Test_queries_called_with_db_name_quoted(t *testing.T) {
 		require.Len(t, mockRunner.calls.runQuery, 1)
 		assert.Equal(t, &timestreamquery.QueryInput{QueryString: aws.String(`SHOW TABLES FROM "db"`)}, mockRunner.calls.runQuery[0])
 	})
-
 }

--- a/pkg/timestream/datasource_test.go
+++ b/pkg/timestream/datasource_test.go
@@ -2,6 +2,8 @@ package timestream
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,9 +23,17 @@ func (f *fakeSender) Send(res *backend.CallResourceResponse) error {
 type fakeRunner struct {
 	queryRunner
 	output *timestreamquery.QueryOutput
+
+	calls runnerCalls
+}
+
+type runnerCalls struct {
+	runQuery []*timestreamquery.QueryInput
 }
 
 func (f *fakeRunner) runQuery(ctx context.Context, input *timestreamquery.QueryInput) (*timestreamquery.QueryOutput, error) {
+	f.calls.runQuery = append(f.calls.runQuery, input)
+
 	return f.output, nil
 }
 
@@ -116,4 +126,37 @@ func TestCallResource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_queries_called_with_db_name_quoted(t *testing.T) {
+	t.Run("db name provided without quotes runs query with quoted db name", func(t *testing.T) {
+		mockRunner := &fakeRunner{output: &timestreamquery.QueryOutput{Rows: []*timestreamquery.Row{}}}
+		ts := &timestreamDS{Runner: mockRunner}
+		sender := &fakeSender{}
+
+		assert.NoError(t, ts.CallResource(context.Background(), &backend.CallResourceRequest{
+			Method: "POST",
+			Path:   "tables",
+			Body:   []byte(`{"database":"db"}`),
+		}, sender))
+
+		require.Len(t, mockRunner.calls.runQuery, 1)
+		assert.Equal(t, &timestreamquery.QueryInput{QueryString: aws.String(`SHOW TABLES FROM "db"`)}, mockRunner.calls.runQuery[0])
+	})
+
+	t.Run("db name provided with quotes runs query with db name as-is", func(t *testing.T) {
+		mockRunner := &fakeRunner{output: &timestreamquery.QueryOutput{Rows: []*timestreamquery.Row{}}}
+		ts := &timestreamDS{Runner: mockRunner}
+		sender := &fakeSender{}
+
+		assert.NoError(t, ts.CallResource(context.Background(), &backend.CallResourceRequest{
+			Method: "POST",
+			Path:   "tables",
+			Body:   []byte(`{"database":"\"db\""}`),
+		}, sender))
+
+		require.Len(t, mockRunner.calls.runQuery, 1)
+		assert.Equal(t, &timestreamquery.QueryInput{QueryString: aws.String(`SHOW TABLES FROM "db"`)}, mockRunner.calls.runQuery[0])
+	})
+
 }


### PR DESCRIPTION
Providing names via the UI (i.e. config editor page) saves the names with `"` double quotes.
In some recent refactoring, we no longer add double quotes when providing names directly from a provisioning file.

This PR checks if the name is already double quoted (for example provided from UI) and if not adds in the quotes (for example provided from provisioning file). 

Fixes #153 