### PR TITLE
Update grafana-aws-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.42.42
 	github.com/google/go-cmp v0.5.7
-	github.com/grafana/grafana-aws-sdk v0.10.1
+	github.com/grafana/grafana-aws-sdk v0.10.3
 	github.com/grafana/grafana-plugin-sdk-go v0.125.0
 )

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/grafana-aws-sdk v0.10.1 h1:Ksguhjx6EuGLN/5Oc7oZoxuDReJ5RxIH99yqSMpLGUs=
 github.com/grafana/grafana-aws-sdk v0.10.1/go.mod h1:vFIOHEnY1u5nY0/tge1IHQjPuG6DRKr2ISf/HikUdjE=
+github.com/grafana/grafana-aws-sdk v0.10.3 h1:nqjK8NfrUyUcAtSjGxnt17ZKjeOMCi62MNKFNagjG6g=
+github.com/grafana/grafana-aws-sdk v0.10.3/go.mod h1:vFIOHEnY1u5nY0/tge1IHQjPuG6DRKr2ISf/HikUdjE=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.125.0 h1:wK2zopAaKhVIMkXzgbExKqZtt+x2ZTGfcY+3wvOuyYQ=
 github.com/grafana/grafana-plugin-sdk-go v0.125.0/go.mod h1:9YiJ5GUxIsIEUC0qR9+BJVP5M7mCSP6uc6Ne62YKkgc=


### PR DESCRIPTION
Ref: https://github.com/grafana/athena-datasource/issues/145

Includes the fix for assuming roles with us-gov regions.