### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## v2.0.0
+
 _Not released yet_
 
 - Breaking Change: Timestream data source now requires Grafana 8.0+ to run.
+- Fix: Allow null data points for time series [#170](https://github.com/grafana/timestream-datasource/pull/170)
 
 ## v1.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## v2.0.0
 
-_Not released yet_
-
 - Breaking Change: Timestream data source now requires Grafana 8.0+ to run.
 - Fix: Allow null data points for time series [#170](https://github.com/grafana/timestream-datasource/pull/170)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -32,8 +32,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaVersion": "7.5.0",
-    "grafanaDependency": ">=7.5.0",
+    "grafanaDependency": ">=8.0.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Include the fix for [#162](https://github.com/grafana/timestream-datasource/issues/168) in the changelog for the upcoming release.

Originally had a PR to release this as v1.5.3 but closed it with this comment https://github.com/grafana/timestream-datasource/pull/171#issuecomment-1145383505