### PR TITLE
Remove label action on prs

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -2,9 +2,6 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled]
-  pull_request:
-    types: [labeled]   
-    branches-ignore: "dependabot/**" 
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When external contributors submit prs, this github action fails for them as they do not have our token in their fork of the repo, and it ends up blocking the ci

IMO I'm not sure we really need this action for prs right now. Perhaps in the future we can revisit if there is a better way to go about this.