### PR TITLE
SQLEditor: Use queryRef to call onChange

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -165,7 +165,7 @@ export function QueryEditor(props: Props) {
         <SQLEditor
           query={query}
           onRunQuery={props.onRunQuery}
-          onChange={(rawQuery) => props.onChange({ ...props.query, rawQuery })}
+          onChange={(query) => props.onChange(query)}
           datasource={props.datasource}
         />
       </div>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -165,7 +165,7 @@ export function QueryEditor(props: Props) {
         <SQLEditor
           query={query}
           onRunQuery={props.onRunQuery}
-          onChange={(query) => props.onChange(query)}
+          onChange={props.onChange}
           datasource={props.datasource}
         />
       </div>

--- a/src/components/SQLEditor.tsx
+++ b/src/components/SQLEditor.tsx
@@ -9,7 +9,7 @@ import timestreamLanguageDefinition from 'language/definition';
 interface RawEditorProps {
   query: TimestreamQuery;
   onRunQuery: () => void;
-  onChange: (q: string) => void;
+  onChange: (query: TimestreamQuery) => void;
   datasource: DataSource;
 }
 
@@ -18,6 +18,10 @@ export default function SQLEditor({ query, datasource, onRunQuery, onChange }: R
   useEffect(() => {
     queryRef.current = query;
   }, [query]);
+
+  const onChangeRawQuery = (rawQuery: string) => {
+    onChange({ ...queryRef.current, rawQuery });
+  };
 
   const getDatabases = useCallback(async () => {
     const databases: string[] = await datasource.postResource('databases').catch(() => []);
@@ -67,7 +71,7 @@ export default function SQLEditor({ query, datasource, onRunQuery, onChange }: R
     <SQLCodeEditor
       query={query.rawQuery ?? ''}
       onBlur={() => onRunQuery()}
-      onChange={(rawQuery) => onChange(rawQuery)}
+      onChange={onChangeRawQuery}
       language={{
         ...timestreamLanguageDefinition,
         completionProvider,


### PR DESCRIPTION
Monaco wrapper SQLCodeEditor does't subscribe to React lifecycle updates, so the component uses queryRef to work with the latest props coming from QueryEditor. The bug was caused by the component having access to a stale _query_ prop, which is why queryRef.current has to be used. 