### PR TITLE
Update version of code-coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -4,7 +4,7 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.10
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.13
     with:
       frontend-path-regexp: src
       backend-path-regexp: pkg\/(timestream|models)


### PR DESCRIPTION
Targets code-coverage version of 0.1.13 which uses node 16. This is necessary in order to update @grafana/ dependencies
See https://github.com/grafana/code-coverage/pull/21