### PR TITLE
Reduce label width to remove whitespace in label

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -140,7 +140,7 @@ export function QueryEditor(props: Props) {
         <InlineField
           id={`${props.query.refId}-wait`}
           label={'Wait for all queries'}
-          labelWidth={18}
+          labelWidth={16}
           style={{ alignItems: 'center' }}
         >
           <Switch


### PR DESCRIPTION
A fix for this:
 <img width="600" alt="Screen Shot 2023-01-02 at 10 30 25 AM" src="https://user-images.githubusercontent.com/16140639/210213905-3ef6a053-03f6-4af2-b8d3-bbce3cad31be.png"> 
 
 comment in an [MR](https://github.com/grafana/timestream-datasource/pull/217) I failed to submit 🙈