### PR TITLE
Query Editor: Stop running query automatically when all macros are selected

### DIFF
--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -113,23 +113,6 @@ describe('QueryEditor', () => {
     });
   });
 
-  it('run a query if it has database, table and measure set', async () => {
-    const onRunQuery = jest.fn();
-    render(
-      <QueryEditor
-        {...props}
-        onRunQuery={onRunQuery}
-        query={{ ...props.query, database: databases[0], table: tables[0], measure: measures[0] }}
-      />
-    );
-
-    await waitFor(() => expect(ds.postResource).toHaveBeenCalledTimes(2));
-    // Measure field is set
-    expect(screen.getByText(measures[0])).toBeInTheDocument();
-
-    expect(onRunQuery).toHaveBeenCalled();
-  });
-
   it('should enable switch to wait for all queries', async () => {
     const onChange = jest.fn();
     render(<QueryEditor {...props} onChange={onChange} />);

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -20,7 +20,7 @@ export function QueryEditor(props: Props) {
 
   // pre-populate query with default data
   useEffect(() => {
-    if (!database || !table || !table) {
+    if (!database || !table || !measure) {
       onChange({
         ...query,
         database: database || defaultDatabase,
@@ -44,13 +44,6 @@ export function QueryEditor(props: Props) {
     onChange({ ...query, rawQuery });
     onRunQuery();
   };
-
-  // Trigger query if all the resources are set
-  useEffect(() => {
-    if (database && table && measure) {
-      onRunQuery();
-    }
-  }, [database, table, measure, onRunQuery]);
 
   // Databases used both for the selector and editor suggestions
   const [databases, setDatabases] = useState<string[]>([]);


### PR DESCRIPTION
[This PR](https://github.com/grafana/grafana/pull/79032/files) in main grafana introduced the bug where onRunQuery function is getting redefined and therefore triggers the useEffect and an infinite loop (reported [here](https://github.com/grafana/grafana/issues/78333#issuecomment-1877217065)). 
The quickest fix is just removing this effect, since we don't want to run query automatically anyway. Furthermore, when the user opens the editor, and selects all the macros, they might not even have anything in the SQL editor, so we don't want to trigger it anyway. 

Also fixed another useEffect typo (I think?) `  if (!database || !table || !table) {`