### PR TITLE
2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.9.0
+
+- Bump jest-dom in [#270](https://github.com/grafana/timestream-datasource/pull/245)
+- Query Editor: Stop running query automatically when all macros are selected in [#269](https://github.com/grafana/timestream-datasource/pull/269)
+- Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.45.0 to 0.46.0 in [#267](https://github.com/grafana/timestream-datasource/pull/267)
+
 ## 2.8.0
 
 - Support Node 18 by @kevinwcyu in https://github.com/grafana/timestream-datasource/pull/245

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -92,6 +92,7 @@
     "typecheck",
     "opentelemetry",
     "httptrace",
-    "otelhttptrace"
+    "otelhttptrace",
+    "otelgrpc"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Load data timestream in grafana",
   "scripts": {
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",


### PR DESCRIPTION
## 2.9.0

- Bump jest-dom in [#270](https://github.com/grafana/timestream-datasource/pull/245)
- Query Editor: Stop running query automatically when all macros are selected in [#269](https://github.com/grafana/timestream-datasource/pull/269)
- Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.45.0 to 0.46.0 in [#267](https://github.com/grafana/timestream-datasource/pull/267)
