### PR TITLE
Query Editor: Fix table and database mapping

### DIFF
--- a/src/components/SQLEditor.tsx
+++ b/src/components/SQLEditor.tsx
@@ -43,10 +43,10 @@ export default function SQLEditor({ query, datasource, onRunQuery, onChange }: R
   const getColumns = useCallback(
     async (database?: string, tableName?: string) => {
       const interpolatedArgs = {
-        database: database ? database.replace(TABLE_MACRO, queryRef.current.table ?? '') : queryRef.current.table,
+        database: database ? database.replace(DATABASE_MACRO, queryRef.current.database ?? '') : queryRef.current.database,
         table: tableName
-          ? tableName.replace(DATABASE_MACRO, queryRef.current.database ?? '')
-          : queryRef.current.database,
+          ? tableName.replace(TABLE_MACRO, queryRef.current.table ?? '')
+          : queryRef.current.table,
       };
       const [measures, dimensions] = await Promise.all([
         datasource.postResource('measures', interpolatedArgs).catch(() => []),


### PR DESCRIPTION
A bug where columns weren't fetched correctly was caused by the typos in these two mappings