### PR TITLE
Add option to format results as timeseries

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -9,6 +9,16 @@ import (
 	"github.com/grafana/timestream-datasource/pkg/common"
 )
 
+// FormatQueryOption defines how the user has chosen to represent the data
+type FormatQueryOption uint32
+
+const (
+	// FormatOptionTable formats the query results as a table using "LongToWide"
+	FormatOptionTable FormatQueryOption = iota
+	//FormatOptionTimeSeries formats the query results as a timeseries using "WideToLong"
+	FormatOptionTimeSeries
+)
+
 // QueryModel represents a spreadsheet query.
 type QueryModel struct {
 	RawQuery  string `json:"rawQuery,omitempty"`
@@ -26,6 +36,9 @@ type QueryModel struct {
 
 	// Return several pages (if exist) in one response
 	WaitForResult bool `json:"waitForResult"`
+
+	// Format the results
+	Format FormatQueryOption `json:"format"`
 }
 
 // GetQueryModel returns a parsed query

--- a/pkg/timestream/executor.go
+++ b/pkg/timestream/executor.go
@@ -46,7 +46,7 @@ func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunn
 		}
 	}
 	if err == nil {
-		dr = QueryResultToDataFrame(output)
+		dr = QueryResultToDataFrame(output, query.Format)
 	} else {
 		dr.Error = err
 	}

--- a/pkg/timestream/helper.go
+++ b/pkg/timestream/helper.go
@@ -13,7 +13,7 @@ import (
 )
 
 // QueryResultToDataFrame creates a DataFrame from query results
-func QueryResultToDataFrame(res *timestreamquery.QueryOutput) (dr backend.DataResponse) {
+func QueryResultToDataFrame(res *timestreamquery.QueryOutput, format models.FormatQueryOption) (dr backend.DataResponse) {
 	dr = backend.DataResponse{}
 	notices := []data.Notice{}
 	builders := []*fieldBuilder{}
@@ -119,6 +119,17 @@ func QueryResultToDataFrame(res *timestreamquery.QueryOutput) (dr backend.DataRe
 		frame := data.NewFrame("", // No name
 			fields...,
 		)
+
+		if format == models.FormatOptionTimeSeries {
+			var err error
+			frame, err = data.LongToWide(frame, &data.FillMissing{
+				Mode: data.FillModeNull,
+			})
+			if err != nil {
+				dr.Error = fmt.Errorf("error formatting as timeseries: %s", err)
+				return
+			}
+		}
 		dr.Frames = append(dr.Frames, frame)
 	}
 

--- a/pkg/timestream/helper_test.go
+++ b/pkg/timestream/helper_test.go
@@ -1,0 +1,106 @@
+package timestream
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/timestreamquery"
+	"github.com/grafana/timestream-datasource/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryResultToDataFrame(t *testing.T) {
+	input := &timestreamquery.QueryOutput{
+		ColumnInfo: []*timestreamquery.ColumnInfo{
+			{
+				Name: aws.String("time"),
+				Type: &timestreamquery.Type{
+					ScalarType: aws.String("TIMESTAMP"),
+				},
+			},
+			{
+				Name: aws.String("instance_name"),
+				Type: &timestreamquery.Type{
+					ScalarType: aws.String("VARCHAR"),
+				},
+			},
+			{
+				Name: aws.String("microservice_name"),
+				Type: &timestreamquery.Type{
+					ScalarType: aws.String("VARCHAR"),
+				},
+			},
+			{
+				Name: aws.String("value"),
+				Type: &timestreamquery.Type{
+					ScalarType: aws.String("DOUBLE"),
+				},
+			},
+		},
+		Rows: []*timestreamquery.Row{
+			{
+				Data: []*timestreamquery.Datum{
+					{ScalarValue: aws.String("2021-03-14 09:52:44.000000000")},
+					{ScalarValue: aws.String("instance-1.amazonaws.com")},
+					{ScalarValue: aws.String("zeus")},
+					{ScalarValue: aws.String("1.2")},
+				},
+			},
+			{
+				Data: []*timestreamquery.Datum{
+					{ScalarValue: aws.String("2021-03-14 09:52:44.000000000")},
+					{ScalarValue: aws.String("instance-1.amazonaws.com")},
+					{ScalarValue: aws.String("apollo")},
+					{ScalarValue: aws.String("1.3")},
+				},
+			},
+			{
+				Data: []*timestreamquery.Datum{
+					{ScalarValue: aws.String("2021-03-14 09:57:44.000000000")},
+					{ScalarValue: aws.String("instance-1.amazonaws.com")},
+					{ScalarValue: aws.String("zeus")},
+					{ScalarValue: aws.String("2.0")},
+				},
+			},
+			{
+				Data: []*timestreamquery.Datum{
+					{ScalarValue: aws.String("2021-03-14 09:57:44.000000000")},
+					{ScalarValue: aws.String("instance-1.amazonaws.com")},
+					{ScalarValue: aws.String("apollo")},
+					{ScalarValue: aws.String("1.5")},
+				},
+			},
+		},
+	}
+
+	t.Run("table format", func(t *testing.T) {
+		res := QueryResultToDataFrame(input, models.FormatOptionTable)
+
+		// Assert that it returns one frame with four fields
+		assert.Equal(t, 1, len(res.Frames))
+		assert.Equal(t, 4, len(res.Frames[0].Fields))
+		assert.Equal(t, "time", res.Frames[0].Fields[0].Name)
+		assert.Equal(t, "instance_name", res.Frames[0].Fields[1].Name)
+		assert.Equal(t, "microservice_name", res.Frames[0].Fields[2].Name)
+		assert.Equal(t, "value", res.Frames[0].Fields[3].Name)
+	})
+
+	t.Run("timeseries format", func(t *testing.T) {
+		res := QueryResultToDataFrame(input, models.FormatOptionTimeSeries)
+		// Assert that it returns one frame with three fields
+		assert.Equal(t, 1, len(res.Frames))
+		assert.Equal(t, 3, len(res.Frames[0].Fields))
+		assert.Equal(t, "time", res.Frames[0].Fields[0].Name)
+
+		// And each field represents a time series
+		assert.Equal(t, "value", res.Frames[0].Fields[1].Name)
+		assert.Equal(t, 2, len(res.Frames[0].Fields[1].Labels))
+		assert.Equal(t, "instance-1.amazonaws.com", res.Frames[0].Fields[1].Labels["instance_name"])
+		assert.Equal(t, "apollo", res.Frames[0].Fields[1].Labels["microservice_name"])
+
+		assert.Equal(t, "value", res.Frames[0].Fields[2].Name)
+		assert.Equal(t, 2, len(res.Frames[0].Fields[2].Labels))
+		assert.Equal(t, "instance-1.amazonaws.com", res.Frames[0].Fields[2].Labels["instance_name"])
+		assert.Equal(t, "zeus", res.Frames[0].Fields[2].Labels["microservice_name"])
+	})
+}

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -10,6 +10,7 @@ import { mockDatasource, mockQuery } from '../__mocks__/datasource';
 import { QueryEditor } from './QueryEditor';
 import { sampleQueries } from './samples';
 import { selectors } from './selectors';
+import { FormatOptions, SelectableFormatOptions } from 'types';
 
 jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({
   getVariables: jest.fn().mockReturnValue([]),
@@ -125,6 +126,21 @@ describe('QueryEditor', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...q,
       waitForResult: true,
+    });
+  });
+
+  it('should set the query format', async () => {
+    const onChange = jest.fn();
+    render(<QueryEditor {...props} onChange={onChange} />);
+
+    const selectEl = screen.getByLabelText('Format as');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, SelectableFormatOptions[1].label!, { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      format: FormatOptions.TimeSeries,
     });
   });
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -4,7 +4,7 @@ import { InlineField, InlineSegmentGroup, Label, Select, Switch } from '@grafana
 import React, { useEffect, useState } from 'react';
 
 import { DataSource } from '../DataSource';
-import { TimestreamOptions, TimestreamQuery } from '../types';
+import { FormatOptions, SelectableFormatOptions, TimestreamOptions, TimestreamQuery } from '../types';
 import { sampleQueries } from './samples';
 import { selectors } from './selectors';
 import SQLEditor from './SQLEditor';
@@ -15,7 +15,7 @@ type QueryProperties = 'database' | 'table' | 'measure';
 
 export function QueryEditor(props: Props) {
   const { query, datasource, onChange, onRunQuery } = props;
-  const { database, table, measure } = query;
+  const { database, table, measure, format } = query;
   const { defaultDatabase, defaultTable, defaultMeasure } = datasource.options;
 
   // pre-populate query with default data
@@ -26,6 +26,7 @@ export function QueryEditor(props: Props) {
         database: database || defaultDatabase,
         table: table || defaultTable,
         measure: measure || defaultMeasure,
+        format: format || FormatOptions.Table,
       });
     }
     // Run only once
@@ -38,6 +39,11 @@ export function QueryEditor(props: Props) {
 
   const onChangeSelector = (prop: QueryProperties) => (e: SelectableValue<string> | null) => {
     onChange({ ...query, [prop]: e?.value });
+  };
+
+  const onChangeFormat = (e: SelectableValue<FormatOptions>) => {
+    onChange({ ...query, format: e.value || 0 });
+    onRunQuery();
   };
 
   const onQueryChange = (rawQuery: string) => {
@@ -140,6 +146,35 @@ export function QueryEditor(props: Props) {
             aria-labelledby={`${props.query.refId}-wait`}
             onChange={onWaitForChange}
             checked={query.waitForResult}
+          />
+        </InlineField>
+        <h6>Frames</h6>
+        <InlineField
+          label="Format as"
+          labelWidth={13}
+          tooltip={
+            <>
+              {
+                'Timeseries queries must have times in ascending order, which can be done by adding "ORDER BY <time field> ASC" to the query. '
+              }
+              <a
+                href="https://docs.aws.amazon.com/timestream/latest/developerguide/supported-sql-constructs.SELECT.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                See the AWS Docs for more details.
+              </a>
+            </>
+          }
+          interactive
+        >
+          <Select
+            aria-label="Format as"
+            options={SelectableFormatOptions}
+            value={props.query.format || FormatOptions.Table}
+            onChange={onChangeFormat}
+            className="width-11"
+            menuShouldPortal={true}
           />
         </InlineField>
         <h6>Sample queries</h6>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -151,6 +151,7 @@ export function QueryEditor(props: Props) {
         <h6>Frames</h6>
         <InlineField
           label="Format as"
+          htmlFor="format-as"
           labelWidth={13}
           tooltip={
             <>
@@ -169,7 +170,7 @@ export function QueryEditor(props: Props) {
           interactive
         >
           <Select
-            aria-label="Format as"
+            inputId="format-as"
             options={SelectableFormatOptions}
             value={props.query.format || FormatOptions.Table}
             onChange={onChangeFormat}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '@grafana/aws-sdk';
-import { DataQuery, DataSourceSettings } from '@grafana/data';
+import { DataQuery, DataSourceSettings, SelectableValue } from '@grafana/data';
 
 export interface ColumnInfo {
   column: string;
@@ -22,6 +22,22 @@ export enum DataType {
   double = 'double',
   timestamp = 'timestamp',
 }
+
+export enum FormatOptions {
+  Table,
+  TimeSeries,
+}
+
+export const SelectableFormatOptions: Array<SelectableValue<FormatOptions>> = [
+  {
+    label: 'Table',
+    value: FormatOptions.Table,
+  },
+  {
+    label: 'Time Series',
+    value: FormatOptions.TimeSeries,
+  },
+];
 
 export interface MeasureInfo {
   name: string;
@@ -67,6 +83,8 @@ export interface TimestreamQuery extends DataQuery {
 
   // Avoid pagination
   waitForResult?: boolean;
+
+  format?: FormatOptions;
 
   // Not a real parameter...
   // nextToken?: string;


### PR DESCRIPTION
Adds an option to format as a timeseries to the query editor to make writing timeseries easier. The users still have to order them correctly for it to work, I decided that doing the parsing to edit the query for them was a bigger chunk of work than we want this to be, but there's a tooltip to help them and the error for non-ordered timestamps itself is pretty helpful.

New interface:
![Screenshot 2024-05-08 at 5 38 28 PM](https://github.com/grafana/timestream-datasource/assets/5421859/c916c0e6-643f-4646-a815-56a417595098)

Fixes #280 