### PR TITLE
Prepare 2.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.9.6
+
+- Bugfix: Fix $interval variable interpolation in [#291](https://github.com/grafana/timestream-datasource/pull/291)
+
 ## 2.9.5
 
 - Chore: update dependencies in [#290](https://github.com/grafana/timestream-datasource/pull/290)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 2.9.6

- Bugfix: Fix $interval variable interpolation in [#291](https://github.com/grafana/timestream-datasource/pull/291)
