### PR TITLE
feat: add errorsource

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/timestream-datasource/pkg/common"
 )
 
@@ -47,7 +48,7 @@ func GetQueryModel(query backend.DataQuery) (*QueryModel, error) {
 
 	err := json.Unmarshal(query.JSON, &model)
 	if err != nil {
-		return nil, fmt.Errorf("error reading query: %s", err.Error())
+		return nil, errorsource.PluginError(fmt.Errorf("error reading query: %s", err.Error()), false)
 	}
 
 	// Copy directly from the well typed query

--- a/pkg/timestream/executor.go
+++ b/pkg/timestream/executor.go
@@ -13,8 +13,7 @@ import (
 )
 
 // ExecuteQuery -- run a query
-func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunner, settings models.DatasourceSettings) (dr backend.DataResponse) {
-	dr = backend.DataResponse{}
+func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunner, settings models.DatasourceSettings) backend.DataResponse {
 
 	raw, err := Interpolate(query, settings)
 	if err != nil {
@@ -45,6 +44,8 @@ func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunn
 			output.NextToken = newPageOutput.NextToken
 		}
 	}
+
+	dr := backend.DataResponse{}
 	if err == nil {
 		dr = QueryResultToDataFrame(output, query.Format)
 	} else {
@@ -79,5 +80,5 @@ func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunn
 	if input.NextToken == nil {
 		meta.StartTime = start
 	}
-	return
+	return dr
 }


### PR DESCRIPTION
This adds errorsource to the response from QueryData to help distinguish between internal and external errors for alerting and investigation purposes.