### PR TITLE
Chore: Update plugin.json keywords

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -16,7 +16,7 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "keywords": ["datasource", "timestream", "aws", "cloud provider", "time series"],
+    "keywords": ["datasource", "timestream", "aws", "amazon", "cloud provider", "time series"],
     "logos": {
       "small": "img/timestream.svg",
       "large": "img/timestream.svg"


### PR DESCRIPTION
Update plugin.json keywords to include "amazon"

Related to https://github.com/grafana/oss-plugin-partnerships/issues/1055