### PR TITLE
Fix errors in LongToWide transformation

### DIFF
--- a/pkg/timestream/helper.go
+++ b/pkg/timestream/helper.go
@@ -119,13 +119,15 @@ func QueryResultToDataFrame(res *timestreamquery.QueryOutput, format models.Form
 
 		frame := data.NewFrame("", fields...)
 
-		if format == models.FormatOptionTimeSeries {
-			var err error
-			frame, err = data.LongToWide(frame, &data.FillMissing{
-				Mode: data.FillModeNull,
-			})
-			if err != nil {
-				return errorsource.Response(errorsource.PluginError(fmt.Errorf("error formatting as timeseries: %s", err), false))
+		if length > 0 && format == models.FormatOptionTimeSeries {
+			if frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
+				var err error
+				frame, err = data.LongToWide(frame, &data.FillMissing{
+					Mode: data.FillModeNull,
+				})
+				if err != nil {
+					return errorsource.Response(errorsource.PluginError(fmt.Errorf("error formatting as timeseries: %s", err), false))
+				}
 			}
 		}
 		dr.Frames = append(dr.Frames, frame)

--- a/pkg/timestream/helper_test.go
+++ b/pkg/timestream/helper_test.go
@@ -103,4 +103,14 @@ func TestQueryResultToDataFrame(t *testing.T) {
 		assert.Equal(t, "instance-1.amazonaws.com", res.Frames[0].Fields[2].Labels["instance_name"])
 		assert.Equal(t, "zeus", res.Frames[0].Fields[2].Labels["microservice_name"])
 	})
+	t.Run("timeseries format with no rows", func(t *testing.T) {
+		input.Rows = []*timestreamquery.Row{}
+		inputWithNoRows := input
+		inputWithNoRows.Rows = []*timestreamquery.Row{}
+		res := QueryResultToDataFrame(inputWithNoRows, models.FormatOptionTimeSeries)
+		// Assert that it returns one frame with no fields
+		assert.Equal(t, 1, len(res.Frames))
+		assert.Equal(t, 4, len(res.Frames[0].Fields))
+		assert.Equal(t, 0, res.Frames[0].Fields[0].Len())
+	})
 }


### PR DESCRIPTION
Errors reported as plugin errors: https://github.com/grafana/data-sources/issues/106

- checks that the series isn't empty
- checks that the series is indeed type Long before calling LongToWide