### PR TITLE
v2.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.9.9
 
+- Fix errors in LongToWide transformation in [#311](https://github.com/grafana/timestream-datasource/pull/311)
 - Chore: Update plugin.json keywords in [#310](https://github.com/grafana/timestream-datasource/pull/310)
 - Update grafana-plugin-sdk-go and grafana-aws-sdk in [#309](https://github.com/grafana/timestream-datasource/pull/309)
 - fix: linter complaints in [#308](https://github.com/grafana/timestream-datasource/pull/308)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.9.9
+
+- Chore: Update plugin.json keywords in [#310](https://github.com/grafana/timestream-datasource/pull/310)
+- Update grafana-plugin-sdk-go and grafana-aws-sdk in [#309](https://github.com/grafana/timestream-datasource/pull/309)
+- fix: linter complaints in [#308](https://github.com/grafana/timestream-datasource/pull/308)
+- Bump path-to-regexp from 1.8.0 to 1.9.0 in [#303](https://github.com/grafana/timestream-datasource/pull/303)
+- Docs: Updates and improvements in [#302](https://github.com/grafana/timestream-datasource/pull/302)
+- Add dependabot for grafana/plugin-sdk-go in [#307](https://github.com/grafana/timestream-datasource/pull/301)
+
 ## 2.9.8
 
 - Bump webpack from 5.92.1 to 5.94.0 in [#301](https://github.com/grafana/timestream-datasource/pull/301)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - fix: linter complaints in [#308](https://github.com/grafana/timestream-datasource/pull/308)
 - Bump path-to-regexp from 1.8.0 to 1.9.0 in [#303](https://github.com/grafana/timestream-datasource/pull/303)
 - Docs: Updates and improvements in [#302](https://github.com/grafana/timestream-datasource/pull/302)
-- Add dependabot for grafana/plugin-sdk-go in [#307](https://github.com/grafana/timestream-datasource/pull/301)
+- Add dependabot for grafana/plugin-sdk-go in [#307](https://github.com/grafana/timestream-datasource/pull/307)
 
 ## 2.9.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.9.9
 
+- Fix "Wait for All Queries" toggle in [#313](https://github.com/grafana/timestream-datasource/pull/313)
 - Fix errors in LongToWide transformation in [#311](https://github.com/grafana/timestream-datasource/pull/311)
 - Chore: Update plugin.json keywords in [#310](https://github.com/grafana/timestream-datasource/pull/310)
 - Update grafana-plugin-sdk-go and grafana-aws-sdk in [#309](https://github.com/grafana/timestream-datasource/pull/309)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION

## 2.9.9

- Chore: Update plugin.json keywords in [#310](https://github.com/grafana/timestream-datasource/pull/310)
- Update grafana-plugin-sdk-go and grafana-aws-sdk in [#309](https://github.com/grafana/timestream-datasource/pull/309)
- fix: linter complaints in [#308](https://github.com/grafana/timestream-datasource/pull/308)
- Bump path-to-regexp from 1.8.0 to 1.9.0 in [#303](https://github.com/grafana/timestream-datasource/pull/303)
- Docs: Updates and improvements in [#302](https://github.com/grafana/timestream-datasource/pull/302)
- Add dependabot for grafana/plugin-sdk-go in [#307](https://github.com/grafana/timestream-datasource/pull/301)
