### PR TITLE
Bugfix: Account for template variables that resolve to a number, prepare 2.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.9.10
+
+- Bugfix: Account for template variable being a number
+- Chore: update dependabot config (#317)
+- Dependency updates: 
+  - Upgrade grafana-plugin-sdk-go (deps): Bump github.com/grafana/grafana-plugin-sdk-go from 0.251.0 to 0.258.0 in [#314](https://github.com/grafana/timestream-datasource/pull/314),[#315](https://github.com/grafana/timestream-datasource/pull/315), [#319](https://github.com/grafana/timestream-datasource/pull/319)
+  - Updates github.com/aws/aws-sdk-go from 1.51.31 to 1.55.5 in [#319](https://github.com/grafana/timestream-datasource/pull/319)
+  - Updates github.com/grafana/grafana-aws-sdk from 0.31.2 to 0.31.3 in [#319](https://github.com/grafana/timestream-datasource/pull/319)
+  - Updates actions/checkout from 2 to 4 in [#318](https://github.com/grafana/timestream-datasource/pull/318)
+  - Updates tibdex/github-app-token from 1.8.0 to 2.1.0 in [#318](https://github.com/grafana/timestream-datasource/pull/318)
+
 ## 2.9.9
 
 - Fix "Wait for All Queries" toggle in [#313](https://github.com/grafana/timestream-datasource/pull/313)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -95,6 +95,7 @@
     "otelhttptrace",
     "otelgrpc",
     "sqlutil",
-    "errorsource"
+    "errorsource",
+    "tibdex"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -46,7 +46,7 @@ describe('DataSource', () => {
       expect(res.rawQuery).toEqual(`select * from foo where var in ('foo','bar')`);
     });
 
-    it('should replace __interval interpolated variables with their original string', () => {
+    it('should return number variables', () => {
       mockDatasource.applyTemplateVariables(
         { ...mockQuery, rawQuery: 'select $__interval_ms, $__interval' },
         {
@@ -55,8 +55,8 @@ describe('DataSource', () => {
         }
       );
       // check rawQuery.replace is called with correct interval value
-      expect(replaceMock.mock.calls[3][1].__interval).toEqual({ value: '$__interval' });
-      expect(replaceMock.mock.calls[3][1].__interval_ms).toEqual({ value: '$__interval_ms' });
+      expect(replaceMock.mock.calls[3][1].__interval).toEqual({ value: 50000 });
+      expect(replaceMock.mock.calls[3][1].__interval_ms).toEqual({ value: 5000000 });
     });
   });
 });

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -55,8 +55,12 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     return query.rawQuery ?? '';
   }
 
-  private interpolateVariable = (value: string | string[]) => {
+  private interpolateVariable = (value: string | string[] | number) => {
     if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'number') {
       return value;
     }
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -80,14 +80,6 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     }
 
     const variables = { ...scopedVars };
-    // We want to interpolate these variables on backend.
-    // The pre-calculated values are replaced with the variable strings.
-    variables.__interval = {
-      value: '$__interval',
-    };
-    variables.__interval_ms = {
-      value: '$__interval_ms',
-    };
 
     const templateSrv = getTemplateSrv();
     return {


### PR DESCRIPTION
We got a [bug report](https://github.com/grafana/support-escalations/issues/11196) where it seems like [this](https://github.com/grafana/timestream-datasource/pull/291/files#top) bugfix didn't account for cases when there's a template variable that resolves to a number and that's not one of the macros `$__interval` and `$__interval_ms`.
 
I think the culprit might be the `$__from` macro which ends up here as a number and causes the error `e.map is not a function`. Since we don't handle that one (and probably multiple others) on the Timestream backend, we probably want to at least return the number. 
In the new scenes architecture, these variables end up being interpolated on the frontend.  
The same solution has been applied [elsewhere](https://github.com/grafana/grafana/blob/846927f0905b41db44c5dd29f143cd0f8640ef99/public/app/features/plugins/sql/datasource/SqlDatasource.ts#L88). I removed the old fix since, if Scenes interpolate these on the frontend, we dont want to have to replace another macro every time Grafana decides to support a new one. 
