### PR TITLE
Bugfix: interpolate interval on the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.9.11
+
+- Bugfix: interpolate interval on the backend [#327](https://github.com/grafana/timestream-datasource/pull/327)
+
 ## 2.9.10
 
 - Bugfix: Account for template variable being a number
 - Chore: update dependabot config (#317)
-- Dependency updates: 
+- Dependency updates:
   - github.com/grafana/grafana-plugin-sdk-go from 0.251.0 to 0.258.0 in [#314](https://github.com/grafana/timestream-datasource/pull/314),[#315](https://github.com/grafana/timestream-datasource/pull/315), [#319](https://github.com/grafana/timestream-datasource/pull/319)
   - github.com/aws/aws-sdk-go from 1.51.31 to 1.55.5 in [#319](https://github.com/grafana/timestream-datasource/pull/319)
   - github.com/grafana/grafana-aws-sdk from 0.31.2 to 0.31.4 in [#319](https://github.com/grafana/timestream-datasource/pull/319)
@@ -32,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Bump fast-loops from 1.1.3 to 1.1.4 in [#298](https://github.com/grafana/timestream-datasource/pull/298)
 
 ## 2.9.7
+
 - feat: add errorsource [#296](https://github.com/grafana/timestream-datasource/pull/296)
 - chore: refactor macros to avoid macro-length bug in [#295](https://github.com/grafana/timestream-datasource/pull/295)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -47,6 +47,7 @@ describe('DataSource', () => {
     });
 
     it('should replace __interval interpolated variables with their original string', () => {
+      replaceMock.mockClear();
       mockDatasource.applyTemplateVariables(
         { ...mockQuery, rawQuery: 'select $__interval_ms, $__interval' },
         {
@@ -60,6 +61,7 @@ describe('DataSource', () => {
     });
 
     it('should return number variables', () => {
+      replaceMock.mockClear();
       mockDatasource.applyTemplateVariables(
         { ...mockQuery, rawQuery: 'select $__from' },
         {

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -12,15 +12,15 @@ describe('DataSource', () => {
       __interval: { value: 50000 },
     };
     // simplified version of getTemplateSrv().replace
-    const replaceMock = jest.fn().mockImplementation(
-      (target?: string, scopedVars?: ScopedVars, format?: string | Function) => {
+    const replaceMock = jest
+      .fn()
+      .mockImplementation((target?: string, scopedVars?: ScopedVars, format?: string | Function) => {
         let res = target ?? '';
         if (scopedVars && typeof format === 'function') {
           Object.keys(scopedVars).forEach((v) => (res = res.replace(v, format(scopedVars[v]?.value))));
         }
         return res;
-      }
-    );
+      });
     beforeEach(() => {
       jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({
         getVariables: jest.fn(),
@@ -46,7 +46,7 @@ describe('DataSource', () => {
       expect(res.rawQuery).toEqual(`select * from foo where var in ('foo','bar')`);
     });
 
-    it('should return number variables', () => {
+    it('should replace __interval interpolated variables with their original string', () => {
       mockDatasource.applyTemplateVariables(
         { ...mockQuery, rawQuery: 'select $__interval_ms, $__interval' },
         {
@@ -55,8 +55,19 @@ describe('DataSource', () => {
         }
       );
       // check rawQuery.replace is called with correct interval value
-      expect(replaceMock.mock.calls[3][1].__interval).toEqual({ value: 50000 });
-      expect(replaceMock.mock.calls[3][1].__interval_ms).toEqual({ value: 5000000 });
+      expect(replaceMock.mock.calls[3][1].__interval).toEqual({ value: '$__interval' });
+      expect(replaceMock.mock.calls[3][1].__interval_ms).toEqual({ value: '$__interval_ms' });
+    });
+
+    it('should return number variables', () => {
+      mockDatasource.applyTemplateVariables(
+        { ...mockQuery, rawQuery: 'select $__from' },
+        {
+          __from: { value: 3000 },
+        }
+      );
+      // check rawQuery.replace is called with correct interval value
+      expect(replaceMock.mock.calls[3][1].__from).toEqual({ value: 3000 });
     });
   });
 });

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -82,6 +82,16 @@ export class DataSource extends DataSourceWithBackend<TimestreamQuery, Timestrea
     const variables = { ...scopedVars };
 
     const templateSrv = getTemplateSrv();
+
+    // We want to interpolate these variables on backend.
+    // The pre-calculated values are replaced with the variable strings.
+    variables.__interval = {
+      value: '$__interval',
+    };
+    variables.__interval_ms = {
+      value: '$__interval_ms',
+    };
+
     return {
       ...query,
       database: templateSrv.replace(query.database || '', scopedVars),


### PR DESCRIPTION
In https://github.com/grafana/timestream-datasource/pull/323 , we stopped sending the `$__interval` and `$__interval_ms` variables to be interpolated on the backend, but they still need to be interpolated on the backend because the [backend interpolates them ](https://github.com/grafana/timestream-datasource/blob/2ddda28b42c789cb528c9b27de12c2ec97e7c496/pkg/timestream/macros.go#L56)as `<time>ms` instead of `<time>`, which is what the frontend interpolates `$__interval_ms` as. This pr preserves the fix for number variables and the fix for the interval variables.