### PR TITLE
Add external PRs to project board

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -8,5 +8,14 @@
     "ignoreList": ["renovate[bot]", "dependabot[bot]", "grafana-delivery-bot[bot]", "grafanabot"],
     "action": "updateLabel",
     "addLabel": "pr/external"
+  },
+  {
+    "type": "label",
+    "name": "pr/external",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97",
+      "column": "Incoming"
+    }
   }
 ]

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -2,6 +2,7 @@ name: PR automation
 on:
   pull_request_target:
     types:
+      - labeled
       - opened
 concurrency:
   group: pr-commands-${{ github.event.number }}


### PR DESCRIPTION
Following up https://github.com/grafana/timestream-datasource/pull/362.

This will add PRs with the `pr/external` label to our project board's incoming column. The previous PR only added the `px/external` label, I didn't realize that PRs don't get automatically added to our board as well so this [test PR](https://github.com/grafana/timestream-datasource/pull/363) wasn't showing up on our board.