### PR TITLE
Prepare 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.10.0
+
+- Migrate form to new styling in [#375](https://github.com/grafana/timestream-datasource/pull/375)
+- Add external PRs to project board in [#366](https://github.com/grafana/timestream-datasource/pull/366)
+- Chore: add label to external contributions in [#362](https://github.com/grafana/timestream-datasource/pull/362)
+- Migrate E2E tests to Playwright in [#358](https://github.com/grafana/timestream-datasource/pull/358)
+- Dependabot: 
+  - Bump the all-node-dependencies group across 1 directory with 7 updates in [#377](https://github.com/grafana/timestream-datasource/pull/377)
+  - Bump the all-go-dependencies group across 1 directory with 3 updates in [#376](https://github.com/grafana/timestream-datasource/pull/376)
+  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.265.0 to 0.266.0 in the all-go-dependencies group in [#372](https://github.com/grafana/timestream-datasource/pull/372)
+  - Bump the all-node-dependencies group across 1 directory with 22 updates in [#370](https://github.com/grafana/timestream-datasource/pull/370)
+  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.262.0 to 0.265.0 in the all-go-dependencies group across 1 directory in [#368](https://github.com/grafana/timestream-datasource/pull/368)
+
 ## 2.9.13
 
 - Bump the all-node-dependencies group across 1 directory with 21 updates in [#352](https://github.com/grafana/timestream-datasource/pull/352)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Compatibility
+
+AWS Timestram datasource plugin >=2.9.13 is not compatible with Grafana versions <=10.4.x due to a breaking change in UI components.
+
 # AWS Timestream Datasource Development Guide
 
 The Timestream datasource plugin provides a support for [Amazon Timestream](https://aws.amazon.com/timestream/). Add it as a data source, then you are ready to build dashboards using timestream query results

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Compatibility
 
-AWS Timestram datasource plugin >=2.9.13 is not compatible with Grafana versions <=10.4.x due to a breaking change in UI components.
+AWS Timestream datasource plugin >=2.9.13 is not compatible with Grafana versions <=10.4.x due to a breaking change in UI components.
 
 # AWS Timestream Datasource Development Guide
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.9.13",
+  "version": "2.10.0",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Also added a compatibility note, since dependabot updated aws-sdk-react in 2.9.13, which is not compatible with older versions of grafana. Since then the plugin has been released so wanted to at least add a note inn the readme

## 2.10.0

- Migrate form to new styling in [#375](https://github.com/grafana/timestream-datasource/pull/375)
- Add external PRs to project board in [#366](https://github.com/grafana/timestream-datasource/pull/366)
- Chore: add label to external contributions in [#362](https://github.com/grafana/timestream-datasource/pull/362)
- Migrate E2E tests to Playwright in [#358](https://github.com/grafana/timestream-datasource/pull/358)
- Dependabot: 
  - Bump the all-node-dependencies group across 1 directory with 7 updates in [#377](https://github.com/grafana/timestream-datasource/pull/377)
  - Bump the all-go-dependencies group across 1 directory with 3 updates in [#376](https://github.com/grafana/timestream-datasource/pull/376)
  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.265.0 to 0.266.0 in the all-go-dependencies group in [#372](https://github.com/grafana/timestream-datasource/pull/372)
  - Bump the all-node-dependencies group across 1 directory with 22 updates in [#370](https://github.com/grafana/timestream-datasource/pull/370)
  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.262.0 to 0.265.0 in the all-go-dependencies group across 1 directory in [#368](https://github.com/grafana/timestream-datasource/pull/368)