### PR TITLE
Update minimum Grafana supported version in plugin.json 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.10.1
+
+- Update minimum Grafana supported version in plugin.json 
+
 ## 2.10.0
 
 - Migrate form to new styling in [#375](https://github.com/grafana/timestream-datasource/pull/375)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -32,7 +32,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=9.5.13",
+    "grafanaDependency": ">=10.4.x",
     "plugins": []
   }
 }


### PR DESCRIPTION
Forgot to update the min supported GF version when I updated the Readme: https://github.com/grafana/timestream-datasource/issues/381