### PR TITLE
Chore: Migrate to Github actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,47 @@
+name: Plugins - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "ops"
+          - "prod"
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      golangci-lint-version: '2.0.2'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false
+
+      # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
+      # (and hide it for on-prem). This is required for some provisioned plugins.
+      # scopes: grafana_cloud
+
+      # Also deploy the plugin to Grafana Cloud via Argo. You also have to follow the Argo Workflows setup guide for this to work.
+      # grafana-cloud-deployment-type: provisioned
+      # argo-workflow-slack-channel: "#grafana-plugins-platform-ci"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,22 @@
+name: Plugins - CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      golangci-lint-version: '2.0.2'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false


### PR DESCRIPTION
This migrates the plugin CI/CD processes to Github actions according to [this migration guide](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/020-migrating-form-drone/)

Right now the shared workflows don't have a mechanism to specify custom Vault secrets in e2e tests, so I had to disable the shared e2e workflow and keep our old e2e action. This might change in the future, but with drone sunset coming up, we don't really have a choice. More info [in this thread ](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750077883269419?thread_ts=1750072014.548489&cid=C01C4K8DETW)