### PR TITLE
Release v2.12.2 (no changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.12.2
+- Releasing for internal deployment testing, no actual changes
+
 ## 2.12.1
 - Mark legacy query format as downstream error by @njvrzm in [#431](https://github.com/grafana/timestream-datasource/pull/431)
 - Chore: migrate to Github actions by @idastambuk in [#425](https://github.com/grafana/timestream-datasource/pull/425)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-timestream-datasource",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Load data timestream in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Needed for internal deployment testing.