### PR TITLE
Add e2e smoke tests that dont require credentials

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,11 @@ on:
 permissions: {}
 
 jobs:
+  # Full CI (including the e2e suite that needs Vault secrets / AWS credentials).
+  # Runs for pushes to main and for PRs opened from branches in this repo.
   ci:
     name: CI
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: read
@@ -20,3 +23,17 @@ jobs:
       playwright-secrets: |
         ACCESS_KEY=timestream:secure_accessKey
         SECRET_KEY=timestream:secure_secretKey
+
+  # Fork PRs don't have access to Vault secrets, so they can't run the full e2e
+  # suite. Instead they run the secret-free smoke tests, which validate that the
+  # config, query and variable editors load correctly.
+  ci-fork:
+    name: CI (fork)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event.pull_request.head.sha }}
+      playwright-config: playwright.smoke.config.ts

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,31 +9,18 @@ on:
 permissions: {}
 
 jobs:
-  # Full CI (including the e2e suite that needs Vault secrets / AWS credentials).
-  # Runs for pushes to main and for PRs opened from branches in this repo.
   ci:
     name: CI
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: read
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      # Fork and Dependabot PRs don't have access to Vault secrets, so they can't
+      # run the full e2e suite. They run the secret-free smoke tests instead,
+      # which validate that the config, query and variable editors load correctly.
+      playwright-config: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]')) && 'playwright.smoke.config.ts' || 'playwright.config.ts' }}
       playwright-secrets: |
         ACCESS_KEY=timestream:secure_accessKey
         SECRET_KEY=timestream:secure_secretKey
-
-  # Fork PRs don't have access to Vault secrets, so they can't run the full e2e
-  # suite. Instead they run the secret-free smoke tests, which validate that the
-  # config, query and variable editors load correctly.
-  ci-fork:
-    name: CI (fork)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
-    permissions:
-      contents: read
-      id-token: write
-    with:
-      plugin-version-suffix: ${{ github.event.pull_request.head.sha }}
-      playwright-config: playwright.smoke.config.ts

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+import type { PluginOptions } from '@grafana/plugin-e2e';
+import baseConfig from './playwright.config';
+
+/**
+ * Smoke test config used by fork PRs.
+ *
+ * Fork PRs don't have access to the Vault secrets (AWS credentials) that the
+ * full e2e suite needs, so instead they run the secret-free smoke tests in
+ * ./tests/smoke, which only validate that the config, query and variable
+ * editors load correctly.
+ */
+export default defineConfig<PluginOptions>({
+  ...baseConfig,
+  testDir: './tests/smoke',
+});

--- a/tests/smoke/configEditor.spec.ts
+++ b/tests/smoke/configEditor.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+/**
+ * Smoke test: validates that the config editor renders without needing real
+ * AWS credentials. Fork PRs run these tests because they don't have access to
+ * the Vault secrets required by the full e2e suite.
+ */
+test('config editor should load', async ({ createDataSourceConfigPage, page, readProvisionedDataSource }) => {
+  const ds = await readProvisionedDataSource({ fileName: 'aws-timestream-e2e.yaml', name: 'AWS Timestream E2E' });
+  await createDataSourceConfigPage({ type: ds.type });
+
+  const authProvider = page.getByLabel(/^Authentication Provider/);
+  await expect(authProvider).toBeVisible();
+
+  await authProvider.fill('Access & secret key');
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByLabel('Access Key ID')).toBeVisible();
+  await expect(page.getByLabel('Secret Access Key')).toBeVisible();
+  await expect(page.getByLabel('Default Region')).toBeVisible();
+});

--- a/tests/smoke/queryEditor.spec.ts
+++ b/tests/smoke/queryEditor.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+/**
+ * Smoke test: validates that the query editor renders without needing real
+ * AWS credentials. It only checks that the code editor loads, it does not run
+ * a query against the backend.
+ */
+test('query editor should load', async ({ page, panelEditPage, selectors }) => {
+  await panelEditPage.datasource.set('AWS Timestream E2E');
+
+  await page.waitForFunction(() => window.monaco);
+  const editor = panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container);
+  await expect(editor).toBeVisible();
+});

--- a/tests/smoke/variableQueryEditor.spec.ts
+++ b/tests/smoke/variableQueryEditor.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+/**
+ * Smoke test: validates that the variable query editor renders without needing
+ * real AWS credentials. It only checks that the query input loads, it does not
+ * run a query against the backend.
+ */
+test('variable query editor should load', async ({ variableEditPage, page, selectors }) => {
+  await variableEditPage.datasource.set('AWS Timestream E2E');
+
+  const editor = page.getByTestId(
+    selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsQueryInput
+  );
+  await expect(editor).toBeVisible();
+});


### PR DESCRIPTION
Fork PRs don't have access to the Vault secrets (AWS credentials) the e2e suite needs, so CI fails. This adds a secret-free smoke suite (tests/smoke/) that just validates the config, query, and variable editors load, plus a playwright.smoke.config.ts to run it. The CI workflow now routes fork PRs to these smoke tests while everyone else keeps running the full e2e suite. Fixes the failing CI on #663.