### PR TITLE
Support per-datasource Grafana Assume Role external ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/grafana/timestream-datasource
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.38.0
 	github.com/google/go-cmp v0.7.0
-	github.com/grafana/grafana-aws-sdk v1.4.6
+	github.com/grafana/grafana-aws-sdk v1.5.1
 	github.com/grafana/grafana-plugin-sdk-go v0.292.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25d
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6kE/MWfg7s=
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
-github.com/grafana/grafana-aws-sdk v1.4.6 h1:+kHyOjhfR51b22Cg5XIXEcRQp7IkoRNkjfv58oQKui4=
-github.com/grafana/grafana-aws-sdk v1.4.6/go.mod h1:e6ZKQTnZvmLf1AlYGcT4ywzbMRke8TvB5qbQPs6zmXA=
+github.com/grafana/grafana-aws-sdk v1.5.1 h1:qvqZwc2tzWCj5UAICmj+dYpa9ZQU9DY+zdWu5xj+vro=
+github.com/grafana/grafana-aws-sdk v1.5.1/go.mod h1:9n7/73i1L6E33ozMk2Nb2s4OoOSWqbmYltIoi/AqgJw=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2 h1:6xrNZpe905vzX1pY33Fyet7Oxw5xULcAHm2b8dvNZNY=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2/go.mod h1:MPviZeixuZDc5T3f62FBCCPSOJ51/JocZH5+ZiQ1DmM=
 github.com/grafana/otel-profiling-go v0.6.0 h1:W7lOZaJj4IJISXMcM1UBk3fJF3tzF2OD6MJBJaQp1H8=

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "8.0.1",
     "@eslint/eslintrc": "3.3.6",
     "@eslint/js": "9.39.5",
-    "@grafana/aws-sdk": "0.12.0",
+    "@grafana/aws-sdk": "0.12.1",
     "@grafana/eslint-config": "9.0.0",
     "@grafana/plugin-e2e": "3.10.0",
     "@grafana/tsconfig": "2.2.0",

--- a/pkg/timestream/datasource.go
+++ b/pkg/timestream/datasource.go
@@ -19,6 +19,8 @@ import (
 	timestreamquerytypes "github.com/aws/aws-sdk-go-v2/service/timestreamquery/types"
 )
 
+var newAWSConfigProvider = awsauth.NewConfigProvider
+
 type QueryClient interface {
 	timestreamquery.QueryAPIClient
 	CancelQuery(context.Context, *timestreamquery.CancelQueryInput, ...func(*timestreamquery.Options)) (*timestreamquery.CancelQueryOutput, error)
@@ -46,7 +48,7 @@ func NewDatasource(ctx context.Context, s backend.DataSourceInstanceSettings) (i
 	if region == "" || region == "default" {
 		region = settings.DefaultRegion
 	}
-	cfg, err := awsauth.NewConfigProvider().GetConfig(ctx, awsauth.Settings{
+	cfg, err := newAWSConfigProvider().GetConfig(ctx, awsauth.Settings{
 		LegacyAuthType:     settings.AuthType,
 		AccessKey:          settings.AccessKey,
 		SecretKey:          settings.SecretKey,
@@ -55,9 +57,11 @@ func NewDatasource(ctx context.Context, s backend.DataSourceInstanceSettings) (i
 		CredentialsProfile: settings.Profile,
 		AssumeRoleARN:      settings.AssumeRoleARN,
 		Endpoint:           settings.Endpoint,
-		ExternalID:         settings.ExternalID,
-		UserAgent:          "Timestream",
-		HTTPClient:         httpClient,
+		ExternalID:                 settings.ExternalID,
+		GrafanaExternalID:          settings.GrafanaExternalID,
+		UsePerDatasourceExternalID: settings.UsePerDatasourceExternalID,
+		UserAgent:                  "Timestream",
+		HTTPClient:                 httpClient,
 	})
 	if err != nil {
 		return nil, backend.DownstreamError(err)

--- a/pkg/timestream/datasource_test.go
+++ b/pkg/timestream/datasource_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	timestreamquerytypes "github.com/aws/aws-sdk-go-v2/service/timestreamquery/types"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/grafana/timestream-datasource/pkg/models"
 	"os"
@@ -415,3 +416,29 @@ func TestGenerateTestData(t *testing.T) {
 		}
 	}
 }
+
+type spyConfigProvider struct {
+	captured awsauth.Settings
+}
+
+func (s *spyConfigProvider) GetConfig(_ context.Context, settings awsauth.Settings) (aws.Config, error) {
+	s.captured = settings
+	return aws.Config{}, nil
+}
+
+func TestNewDatasource_passesGrafanaExternalIDFields(t *testing.T) {
+	spy := &spyConfigProvider{}
+	origProvider := newAWSConfigProvider
+	newAWSConfigProvider = func() awsauth.ConfigProvider { return spy }
+	t.Cleanup(func() { newAWSConfigProvider = origProvider })
+
+	inst, err := NewDatasource(context.Background(), backend.DataSourceInstanceSettings{
+		JSONData: []byte(`{"authType":"grafana_assume_role","defaultRegion":"us-east-1","assumeRoleArn":"arn:aws:iam::123456789012:role/test","grafanaExternalId":"stackABC-dsUid1","usePerDatasourceExternalId":true}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	assert.Equal(t, "stackABC-dsUid1", spy.captured.GrafanaExternalID)
+	require.NotNil(t, spy.captured.UsePerDatasourceExternalID)
+	assert.True(t, *spy.captured.UsePerDatasourceExternalID)
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,12 +1742,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@grafana/aws-sdk@npm:0.12.0"
+"@grafana/aws-sdk@npm:0.12.1":
+  version: 0.12.1
+  resolution: "@grafana/aws-sdk@npm:0.12.1"
   peerDependencies:
     "@grafana/plugin-ui": ">=0.14.0"
-  checksum: 10c0/ddaebf62d9f49d89bc5e1d4eba85c7131c92583ad1e382a0e836fcb93e363de2c76929ecb2ccd7ee37518b5b5a3263415988b840affea6b0af510f0294a7a306
+  checksum: 10c0/bda7becad21c72ac27d3308b3d4cd069b84cb3bcede8ce7d13746d7e9e06f8eb92a171c21d6cbeb372caac13e89144a2b2658b2f34bc1df13436d568249e1894
   languageName: node
   linkType: hard
 
@@ -7354,7 +7354,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@eslint/eslintrc": "npm:3.3.6"
     "@eslint/js": "npm:9.39.5"
-    "@grafana/aws-sdk": "npm:0.12.0"
+    "@grafana/aws-sdk": "npm:0.12.1"
     "@grafana/data": "npm:13.1.1"
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/plugin-e2e": "npm:3.10.0"


### PR DESCRIPTION
## Summary
- Forward `GrafanaExternalID` and `UsePerDatasourceExternalID` into `awsauth.Settings` so Grafana Assume Role uses the per-datasource external ID when feature toggle `awsAssumeRolePerDatasourceExternalId` is enabled.
- Bump `github.com/grafana/grafana-aws-sdk` to `v1.5.1` (STS resolution for the per-ds ID).
- Bump `@grafana/aws-sdk` to `0.12.1` so ConnectionConfig can derive the stack ID from `config.namespace` and mint/display `{stack}-{uid}` before save (no plugin `/externalId` fetch required).
- Add a unit test that asserts the new fields are passed through to the AWS config provider.

## Context
Grafana already mints/preserves `jsonData.grafanaExternalId` and `usePerDatasourceExternalId` when the FT is on. This wires those fields through the plugin auth path so STS AssumeRole uses the per-datasource external ID instead of the shared stack ID.

Mirrors CloudWatch: [grafana#129737](https://github.com/grafana/grafana/pull/129737) / [grafana-cloudwatch-datasource#582](https://github.com/grafana/grafana-cloudwatch-datasource/pull/582).

## Test plan
- [x] Unit test for field forwarding passes
- [x] Local: create a Grafana Assume Role datasource with FT on — UI shows `{stack}-{uid}` (including before save once a UID exists)
- [x] Local: after save, `jsonData.grafanaExternalId` / `usePerDatasourceExternalId` are persisted
- [ ] CI green
- [ ] With FT on + Grafana Assume Role, queries/STS use the per-ds external ID
- [ ] With FT off (or toggle disabled), stack external ID behavior is unchanged